### PR TITLE
[🥒 babaco] fix: color, typography, layout & a11y design improvements

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -62,12 +62,12 @@
   --color-chart-4: hsl(var(--chart-4));
   --color-chart-5: hsl(var(--chart-5));
 
-  /* Radius tokens */
-  --radius-card: 14px;
+  /* Radius tokens — unified to px */
+  --radius-card: 16px;
   --radius-widget: 10px;
-  --radius-lg: var(--radius);
-  --radius-md: calc(var(--radius) - 2px);
-  --radius-sm: calc(var(--radius) - 4px);
+  --radius-lg: 12px;
+  --radius-md: 10px;
+  --radius-sm: 8px;
 
   /* Animations */
   --animate-accordion-down: accordion-down 0.2s ease-out;
@@ -104,7 +104,7 @@
   --card-foreground: 0 0% 12%;
 
   /* L2 inner cards */
-  --secondary: 0 0% 100%;
+  --secondary: 330 10% 99%;
   --secondary-foreground: 0 0% 12%;
 
   --popover: 0 0% 100%;
@@ -153,59 +153,59 @@
   --chart-3: 262 47% 50%;
   --chart-4: 32 80% 50%;
   --chart-5: 199 59% 45%;
-  --sidebar: hsl(330 20% 98%);
+  --sidebar: 330 20% 98%;
 }
 
 .dark {
   /* L0 body */
-  --background: 0 0% 9%;
-  --foreground: 0 0% 93%;
+  --background: 330 3% 9%;
+  --foreground: 330 3% 93%;
 
   /* L1 content panel */
-  --card: 0 0% 10.6%;
-  --card-foreground: 0 0% 93%;
+  --card: 330 3% 10.6%;
+  --card-foreground: 330 3% 93%;
 
   /* L2 inner cards */
-  --secondary: 0 0% 12.2%;
-  --secondary-foreground: 0 0% 93%;
+  --secondary: 330 3% 12.2%;
+  --secondary-foreground: 330 3% 93%;
 
-  --popover: 0 0% 10.6%;
-  --popover-foreground: 0 0% 93%;
+  --popover: 330 3% 10.6%;
+  --popover-foreground: 330 3% 93%;
 
   /* Sakura pink primary (muted for dark) */
   --primary: 340 40% 48%;
   --primary-foreground: 340 30% 93%;
 
-  --muted: 0 0% 12.2%;
-  --muted-foreground: 0 0% 48%;
+  --muted: 330 3% 12.2%;
+  --muted-foreground: 330 3% 48%;
 
-  --accent: 0 0% 14%;
-  --accent-foreground: 0 0% 93%;
+  --accent: 330 3% 14%;
+  --accent-foreground: 330 3% 93%;
 
   --destructive: 0 65% 45%;
   --destructive-foreground: 0 65% 92%;
 
-  --border: 0 0% 16%;
-  --input: 0 0% 18%;
+  --border: 330 3% 16%;
+  --input: 330 3% 18%;
   --ring: 340 40% 48%;
 
-  --sidebar-background: 0 0% 9%;
-  --sidebar-foreground: 0 0% 93%;
+  --sidebar-background: 330 3% 9%;
+  --sidebar-foreground: 330 3% 93%;
   --sidebar-primary: 340 40% 48%;
   --sidebar-primary-foreground: 340 30% 93%;
-  --sidebar-accent: 0 0% 14%;
-  --sidebar-accent-foreground: 0 0% 93%;
-  --sidebar-border: 0 0% 16%;
+  --sidebar-accent: 330 3% 14%;
+  --sidebar-accent-foreground: 330 3% 93%;
+  --sidebar-border: 330 3% 16%;
   --sidebar-ring: 340 40% 48%;
 
   /* Semantic */
   --success: 142 65% 38%;
   --success-foreground: 142 60% 90%;
   --info: 199 50% 40%;
-  --info-foreground: 0 0% 96%;
+  --info-foreground: 330 3% 96%;
   --warning: 32 70% 45%;
-  --warning-foreground: 0 0% 10%;
-  --surface-elevated: 0 0% 14%;
+  --warning-foreground: 330 3% 10%;
+  --surface-elevated: 330 3% 14%;
 
   /* Chart palette */
   --chart-1: 340 40% 48%;
@@ -213,7 +213,7 @@
   --chart-3: 262 40% 45%;
   --chart-4: 32 70% 45%;
   --chart-5: 199 50% 40%;
-  --sidebar: hsl(240 5.9% 10%);
+  --sidebar: 330 3% 10%;
 }
 
 /*

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -99,12 +99,12 @@ function LoginContent() {
             className="relative w-72 aspect-[54/86] overflow-hidden rounded-2xl bg-card flex flex-col ring-1 ring-black/[0.08] dark:ring-white/[0.06]"
             style={{
               boxShadow: [
-                "0 1px 2px rgba(0,0,0,0.06)",
-                "0 4px 8px rgba(0,0,0,0.04)",
-                "0 12px 24px rgba(0,0,0,0.06)",
-                "0 24px 48px rgba(0,0,0,0.04)",
-                "0 0 0 0.5px rgba(0,0,0,0.02)",
-                "0 0 60px rgba(0,0,0,0.03)",
+                "0 1px 2px hsl(var(--foreground) / 0.06)",
+                "0 4px 8px hsl(var(--foreground) / 0.04)",
+                "0 12px 24px hsl(var(--foreground) / 0.06)",
+                "0 24px 48px hsl(var(--foreground) / 0.04)",
+                "0 0 0 0.5px hsl(var(--foreground) / 0.02)",
+                "0 0 60px hsl(var(--foreground) / 0.03)",
               ].join(", "),
             }}
           >
@@ -140,7 +140,7 @@ function LoginContent() {
             {/* Badge content */}
             <div className="flex flex-1 flex-col items-center px-6 pt-6 pb-5">
               {/* Logo */}
-              <div className="h-24 w-24 overflow-hidden rounded-full bg-secondary dark:bg-[#171717] ring-1 ring-border flex items-center justify-center">
+              <div className="h-24 w-24 overflow-hidden rounded-full bg-secondary dark:bg-background ring-1 ring-border flex items-center justify-center">
                 <Image src="/logo-80.png" alt="dove" width={80} height={80} className="h-full w-full object-cover" />
               </div>
 

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -3,10 +3,12 @@
 import { signIn } from "next-auth/react";
 import { useSearchParams } from "next/navigation";
 import Image from "next/image";
-import { Suspense } from "react";
+import { Suspense, useState } from "react";
+import { Loader2 } from "lucide-react";
 import { GithubIcon } from "@/components/icons/github";
 import { ThemeToggle } from "@/components/layout/theme-toggle";
 import { SiteFooter } from "@/components/layout/site-footer";
+import { Button } from "@/components/ui/button";
 import { LoginSkeleton } from "@/components/skeletons";
 
 function Barcode() {
@@ -55,7 +57,10 @@ function LoginContent() {
   const year = new Date().getFullYear();
   const today = new Date().toISOString().slice(0, 10).replace(/-/g, "");
 
+  const [isLoading, setIsLoading] = useState(false);
+
   const handleGoogleLogin = () => {
+    setIsLoading(true);
     signIn("google", { callbackUrl });
   };
 
@@ -131,7 +136,7 @@ function LoginContent() {
                 <span className="text-xs font-mono text-primary-foreground/40 tracking-wider">
                   ID {year}-{today.slice(4)}
                 </span>
-                <div className="h-6">
+                <div className="h-6" aria-hidden="true">
                   <Barcode />
                 </div>
               </div>
@@ -163,13 +168,19 @@ function LoginContent() {
               <div className="mt-5" />
 
               {/* Google Sign-in button */}
-              <button
+              <Button
+                variant="secondary"
                 onClick={handleGoogleLogin}
-                className="flex w-full items-center justify-center gap-2.5 rounded-xl bg-secondary px-4 py-3 text-sm font-medium text-foreground transition-colors hover:bg-accent cursor-pointer"
+                disabled={isLoading}
+                className="flex w-full items-center justify-center gap-2.5 rounded-xl px-4 py-3 text-sm font-medium transition-colors cursor-pointer focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
               >
-                <GoogleIcon />
-                Sign in with Google
-              </button>
+                {isLoading ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <GoogleIcon />
+                )}
+                {isLoading ? "Signing in..." : "Sign in with Google"}
+              </Button>
 
               {/* Terms */}
               <p className="mt-3 text-center text-xs leading-relaxed text-muted-foreground/60">

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -115,20 +115,20 @@ function LoginContent() {
                 <div
                   className="h-4 w-8 rounded-full bg-background/80"
                   style={{
-                    boxShadow: "inset 0 1.5px 3px rgba(0,0,0,0.35), inset 0 -0.5px 1px rgba(255,255,255,0.1)",
+                    boxShadow: "inset 0 1.5px 3px hsl(var(--foreground) / 0.35), inset 0 -0.5px 1px hsl(var(--background) / 0.1)",
                   }}
                 />
                 <div className="flex items-center gap-2">
                   <Image src="/logo-24.png" alt="dove" width={16} height={16} className="brightness-0 invert" />
                   <span className="text-sm font-semibold text-primary-foreground">dove</span>
                 </div>
-                <span className="text-[10px] font-medium uppercase tracking-widest text-primary-foreground/60">
+                <span className="text-xs font-medium uppercase tracking-widest text-primary-foreground/60">
                   DEV
                 </span>
               </div>
               {/* Barcode row */}
               <div className="mt-3 flex items-center justify-between">
-                <span className="text-[9px] font-mono text-primary-foreground/40 tracking-wider">
+                <span className="text-xs font-mono text-primary-foreground/40 tracking-wider">
                   ID {year}-{today.slice(4)}
                 </span>
                 <div className="h-6">
@@ -172,7 +172,7 @@ function LoginContent() {
               </button>
 
               {/* Terms */}
-              <p className="mt-3 text-center text-[10px] leading-relaxed text-muted-foreground/60">
+              <p className="mt-3 text-center text-xs leading-relaxed text-muted-foreground/60">
                 Access is restricted to authorized accounts only
               </p>
             </div>
@@ -181,7 +181,7 @@ function LoginContent() {
             <div className="mt-auto flex items-center justify-center border-t border-border bg-secondary/50 py-2.5">
               <div className="flex items-center gap-1.5">
                 <div className="h-1.5 w-1.5 rounded-full bg-success animate-pulse" />
-                <span className="text-[10px] text-muted-foreground">Secure Auth</span>
+                <span className="text-xs text-muted-foreground">Secure Auth</span>
               </div>
             </div>
           </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -85,7 +85,7 @@ export default function DashboardPage() {
     <AppShell>
       <div className="space-y-4 md:space-y-6">
         <div>
-          <h1 className="text-xl font-semibold font-display">Dashboard</h1>
+          <h1 className="text-xl md:text-2xl font-semibold font-display">Dashboard</h1>
           <p className="text-sm text-muted-foreground mt-1">
             Email relay overview and send activity.
           </p>

--- a/src/app/projects/new/page.tsx
+++ b/src/app/projects/new/page.tsx
@@ -64,7 +64,7 @@ export default function NewProjectPage() {
     <AppShell breadcrumbs={[{ label: "Projects", href: "/projects" }, { label: "New" }]}>
       <div className="flex flex-col gap-6 max-w-lg">
         <div>
-          <h1 className="text-xl font-semibold font-display">New Project</h1>
+          <h1 className="text-xl md:text-2xl font-semibold font-display">New Project</h1>
           <p className="text-sm text-muted-foreground mt-1">
             Create an email relay project. A webhook token will be generated automatically.
           </p>

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -99,7 +99,7 @@ export default function ProjectsPage() {
                 <Link
                   key={project.id}
                   href={`/projects/${project.id}`}
-                  className="group rounded-[var(--radius-card)] bg-secondary px-3.5 py-3 transition-colors hover:bg-accent/60"
+                  className="group rounded-[var(--radius-card)] bg-secondary p-4 md:p-5 transition-colors hover:bg-accent/60"
                 >
                   <div className="flex items-center justify-between">
                     <div className="flex items-center gap-2.5 min-w-0">

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -107,8 +107,8 @@ export default function ProjectsPage() {
                         <Mail className="h-4 w-4 text-muted-foreground" strokeWidth={1.5} />
                       </div>
                       <div className="min-w-0">
-                        <p className="text-[13px] font-medium text-foreground truncate">{project.name}</p>
-                        <p className="text-[11px] text-muted-foreground truncate">
+                        <p className="text-sm font-medium text-foreground truncate">{project.name}</p>
+                        <p className="text-xs text-muted-foreground truncate">
                           {project.from_name} · {project.email_prefix} · {project.quota_daily}/day · {project.quota_monthly}/mo
                         </p>
                       </div>
@@ -117,7 +117,7 @@ export default function ProjectsPage() {
                   </div>
 
                   {project.description && (
-                    <p className="text-[11px] text-muted-foreground mt-2 line-clamp-1 pl-[34px]">
+                    <p className="text-xs text-muted-foreground mt-2 line-clamp-1 pl-[34px]">
                       {project.description}
                     </p>
                   )}

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -52,7 +52,7 @@ export default function ProjectsPage() {
         {/* Header */}
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-xl font-semibold font-display">Projects</h1>
+            <h1 className="text-xl md:text-2xl font-semibold font-display">Projects</h1>
             <p className="text-sm text-muted-foreground mt-1">
               Manage email relay projects, quotas, and webhook tokens.
             </p>

--- a/src/app/send-logs/page.tsx
+++ b/src/app/send-logs/page.tsx
@@ -257,40 +257,42 @@ export default function SendLogsPage() {
               </div>
             )}
 
-            {/* Table header — desktop */}
-            <div className="hidden md:flex items-center gap-3 px-4 py-2 text-xs text-muted-foreground border-b border-border">
-              <SortHeader label="Status" sortKey="status" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="w-[80px] shrink-0" />
-              <SortHeader label="Recipient" sortKey="to_email" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="flex-1 min-w-0" />
-              <SortHeader label="Subject" sortKey="subject" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="w-[200px] shrink-0" />
-              <SortHeader label="Project" sortKey="project" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="w-[120px] shrink-0" />
-              <SortHeader label="Date" sortKey="created_at" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="w-[130px] shrink-0" />
-            </div>
+            {/* Table */}
+            <div role="table" aria-label="Send logs">
+              {/* Table header — desktop */}
+              <div role="row" className="hidden md:flex items-center gap-3 px-4 py-2 text-xs text-muted-foreground border-b border-border">
+                <SortHeader label="Status" sortKey="status" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="w-[80px] shrink-0" />
+                <SortHeader label="Recipient" sortKey="to_email" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="flex-1 min-w-0" />
+                <SortHeader label="Subject" sortKey="subject" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="w-[200px] shrink-0" />
+                <SortHeader label="Project" sortKey="project" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="w-[120px] shrink-0" />
+                <SortHeader label="Date" sortKey="created_at" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="w-[130px] shrink-0" />
+              </div>
 
-            <div className="flex flex-col">
+              <div className="flex flex-col">
               {sortedLogs?.map((log) => (
-                <div key={log.id}>
+                <div key={log.id} role="row">
                   <button
                     type="button"
                     onClick={() => setExpandedId(expandedId === log.id ? null : log.id)}
                     className="w-full flex flex-col gap-1 md:flex-row md:items-center md:gap-3 px-4 py-3 text-left border-b border-border hover:bg-muted/30 transition-colors"
                   >
-                    <div className="w-[80px] shrink-0">
+                    <span role="cell" className="w-[80px] shrink-0">
                       <Badge variant={statusVariant(log.status)} className="text-xs">
                         {log.status}
                       </Badge>
-                    </div>
-                    <div className="flex-1 min-w-0 truncate text-sm text-foreground">
+                    </span>
+                    <span role="cell" className="flex-1 min-w-0 truncate text-sm text-foreground">
                       {log.to_email}
-                    </div>
-                    <div className="w-[200px] shrink-0 truncate text-xs text-muted-foreground">
+                    </span>
+                    <span role="cell" className="w-[200px] shrink-0 truncate text-xs text-muted-foreground">
                       {log.subject}
-                    </div>
-                    <div className="w-[120px] shrink-0 text-xs text-muted-foreground truncate">
+                    </span>
+                    <span role="cell" className="w-[120px] shrink-0 text-xs text-muted-foreground truncate">
                       {projectMap.get(log.project_id) ?? log.project_id.slice(0, 8)}
-                    </div>
-                    <div className="w-[130px] shrink-0 text-xs text-muted-foreground">
+                    </span>
+                    <span role="cell" className="w-[130px] shrink-0 text-xs text-muted-foreground">
                       {formatDate(log.created_at)}
-                    </div>
+                    </span>
                   </button>
 
                   {/* Expanded detail */}
@@ -333,7 +335,8 @@ export default function SendLogsPage() {
                     </div>
                   )}
                 </div>
-              ))}
+                ))}
+              </div>
             </div>
 
             {/* Pagination */}

--- a/src/app/send-logs/page.tsx
+++ b/src/app/send-logs/page.tsx
@@ -275,7 +275,7 @@ export default function SendLogsPage() {
                     className="w-full flex flex-col gap-1 md:flex-row md:items-center md:gap-3 px-4 py-3 text-left border-b border-border hover:bg-muted/30 transition-colors"
                   >
                     <div className="w-[80px] shrink-0">
-                      <Badge variant={statusVariant(log.status)} className="text-[10px]">
+                      <Badge variant={statusVariant(log.status)} className="text-xs">
                         {log.status}
                       </Badge>
                     </div>

--- a/src/app/send-logs/page.tsx
+++ b/src/app/send-logs/page.tsx
@@ -182,7 +182,7 @@ export default function SendLogsPage() {
     <AppShell breadcrumbs={[{ label: "Send Logs", href: "/send-logs" }]}>
       <div className="flex flex-col gap-6">
         <div>
-          <h1 className="text-xl font-semibold font-display">Send Logs</h1>
+          <h1 className="text-xl md:text-2xl font-semibold font-display">Send Logs</h1>
           <p className="text-sm text-muted-foreground mt-1">
             Authoritative email send history.
           </p>

--- a/src/app/templates/[id]/page.tsx
+++ b/src/app/templates/[id]/page.tsx
@@ -429,7 +429,7 @@ export default function TemplateDetailPage({
           </div>
 
           {/* Right: Preview */}
-          <Card className="sticky top-0 self-start">
+          <Card className="sticky top-[72px] self-start">
             <CardHeader>
               <CardTitle className="text-base">Preview</CardTitle>
               <CardDescription>Rendered email output.</CardDescription>
@@ -474,7 +474,7 @@ export default function TemplateDetailPage({
 
               {previewSubject && (
                 <div>
-                  <p className="text-[10px] uppercase tracking-wider text-muted-foreground mb-1">Subject</p>
+                  <p className="text-xs uppercase tracking-wider text-muted-foreground mb-1">Subject</p>
                   <p className="text-sm font-medium text-foreground">{previewSubject}</p>
                 </div>
               )}

--- a/src/app/templates/[id]/page.tsx
+++ b/src/app/templates/[id]/page.tsx
@@ -480,7 +480,7 @@ export default function TemplateDetailPage({
               )}
 
               {previewHtml ? (
-                <div className="rounded-lg border border-border bg-white p-4 overflow-auto max-h-[500px]">
+                <div className="rounded-lg border border-border bg-background p-4 overflow-auto max-h-[500px]">
                   <div
                     className="prose prose-sm max-w-none text-foreground"
                     dangerouslySetInnerHTML={{ __html: previewHtml }}

--- a/src/app/templates/new/page.tsx
+++ b/src/app/templates/new/page.tsx
@@ -131,7 +131,7 @@ function NewTemplateForm() {
   return (
     <div className="flex flex-col gap-6 max-w-2xl">
       <div>
-        <h1 className="text-xl font-semibold font-display">New Template</h1>
+        <h1 className="text-xl md:text-2xl font-semibold font-display">New Template</h1>
         <p className="text-sm text-muted-foreground mt-1">
           Create a Markdown email template with optional variables.
         </p>

--- a/src/app/templates/page.tsx
+++ b/src/app/templates/page.tsx
@@ -73,7 +73,7 @@ export default function TemplatesPage() {
         {/* Header */}
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-xl font-semibold font-display">Templates</h1>
+            <h1 className="text-xl md:text-2xl font-semibold font-display">Templates</h1>
             <p className="text-sm text-muted-foreground mt-1">
               Email templates across all projects.
             </p>

--- a/src/app/templates/page.tsx
+++ b/src/app/templates/page.tsx
@@ -118,7 +118,7 @@ export default function TemplatesPage() {
                     <Link
                       key={t.id}
                       href={`/templates/${t.id}`}
-                      className="flex items-center gap-3 px-4 py-3 hover:bg-muted/30 transition-colors"
+                      className="flex items-center gap-3 px-4 py-3 hover:bg-muted/50 transition-colors duration-150"
                     >
                       <div className="min-w-0 flex-1">
                         <p className="text-sm font-medium text-foreground truncate">{t.name}</p>
@@ -128,7 +128,7 @@ export default function TemplatesPage() {
                           <span>{t.subject}</span>
                         </p>
                       </div>
-                      <time className="hidden sm:block text-[11px] text-muted-foreground tabular-nums shrink-0">
+                      <time className="hidden sm:block text-xs text-muted-foreground tabular-nums shrink-0">
                         {new Date(t.updated_at).toLocaleDateString(undefined, { month: "short", day: "numeric" })}
                       </time>
                     </Link>

--- a/src/app/templates/page.tsx
+++ b/src/app/templates/page.tsx
@@ -110,7 +110,7 @@ export default function TemplatesPage() {
           <div className="flex flex-col gap-6">
             {Array.from(grouped.entries()).map(([projectId, tmps]) => (
               <div key={projectId}>
-                <h2 className="text-sm font-medium text-muted-foreground mb-3">
+                <h2 className="text-sm font-medium text-muted-foreground uppercase tracking-wide mb-3">
                   {projectMap.get(projectId) ?? "Unknown Project"}
                 </h2>
                 <div className="divide-y divide-border/50 rounded-xl bg-secondary overflow-hidden">

--- a/src/app/webhook-logs/page.tsx
+++ b/src/app/webhook-logs/page.tsx
@@ -257,7 +257,7 @@ export default function WebhookLogsPage() {
                     className="w-full flex flex-col gap-1 md:flex-row md:items-center md:gap-3 px-4 py-3 text-left border-b border-border hover:bg-muted/30 transition-colors"
                   >
                     <div className="w-[60px] shrink-0">
-                      <Badge variant={statusCodeVariant(log.status_code)} className="text-[10px] font-mono">
+                      <Badge variant={statusCodeVariant(log.status_code)} className="text-xs font-mono">
                         {log.status_code}
                       </Badge>
                     </div>

--- a/src/app/webhook-logs/page.tsx
+++ b/src/app/webhook-logs/page.tsx
@@ -175,7 +175,7 @@ export default function WebhookLogsPage() {
     <AppShell breadcrumbs={[{ label: "Webhook Logs", href: "/webhook-logs" }]}>
       <div className="flex flex-col gap-6">
         <div>
-          <h1 className="text-xl font-semibold font-display">Webhook Logs</h1>
+          <h1 className="text-xl md:text-2xl font-semibold font-display">Webhook Logs</h1>
           <p className="text-sm text-muted-foreground mt-1">
             Fire-and-forget request logs for observability.
           </p>

--- a/src/components/charts/sends-chart.tsx
+++ b/src/components/charts/sends-chart.tsx
@@ -116,7 +116,7 @@ export function SendsChart({ data }: { data: ChartPoint[] }) {
           </span>
         </div>
         <div className="flex items-center gap-1.5">
-          <span className="inline-block h-2.5 w-2.5 rounded-sm" style={{ backgroundColor: "hsl(var(--chart-5))" }} />
+          <span className="inline-block h-2.5 w-2.5 rounded-sm" style={{ backgroundColor: "hsl(var(--destructive))" }} />
           <span className="text-xs text-muted-foreground">
             Failed: <span className="font-medium text-foreground">{totalFailed}</span>
           </span>

--- a/src/components/charts/sends-chart.tsx
+++ b/src/components/charts/sends-chart.tsx
@@ -47,7 +47,7 @@ export function SendsChart({ data }: { data: ChartPoint[] }) {
   if (data.length === 0) {
     return (
       <div className="rounded-[var(--radius-card)] bg-secondary p-4 md:p-5">
-        <p className="text-xs md:text-sm text-muted-foreground mb-4">Sends Over Time</p>
+        <p className="text-sm font-medium text-foreground mb-4">Sends Over Time</p>
         <div className="flex h-[200px] items-center justify-center">
           <p className="text-sm text-muted-foreground">No data available</p>
         </div>
@@ -66,7 +66,7 @@ export function SendsChart({ data }: { data: ChartPoint[] }) {
 
   return (
     <div className="rounded-[var(--radius-card)] bg-secondary p-4 md:p-5">
-      <p className="text-xs md:text-sm text-muted-foreground mb-4">Sends Over Time</p>
+      <p className="text-sm font-medium text-foreground mb-4">Sends Over Time</p>
       <ResponsiveContainer width="100%" height={200}>
         <BarChart
           data={chartData}
@@ -102,7 +102,7 @@ export function SendsChart({ data }: { data: ChartPoint[] }) {
           />
           <Bar
             dataKey="failed"
-            fill="hsl(var(--chart-5))"
+            fill="hsl(var(--destructive))"
             radius={[3, 3, 0, 0]}
             stackId="a"
           />

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -162,8 +162,8 @@ function AppShellInner({ children, breadcrumbs = [] }: AppShellProps) {
         </header>
 
         {/* Floating island content area */}
-        <div className="flex-1 px-2 pb-2 md:px-3 md:pb-3">
-          <div className="h-full rounded-[16px] md:rounded-[20px] bg-card p-3 md:p-5 overflow-y-auto">
+        <div className="flex-1 px-3 pb-3 md:px-4 md:pb-4">
+          <div className="h-full rounded-[var(--radius-card)] bg-card p-3 md:p-5 overflow-y-auto">
             {children}
           </div>
         </div>

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -140,7 +140,7 @@ export function Sidebar() {
   return (
     <aside
       className={cn(
-        "sticky top-0 flex h-screen shrink-0 flex-col bg-background transition-all duration-300 ease-in-out overflow-hidden",
+        "sticky top-0 flex h-screen shrink-0 flex-col bg-background transition-[width] duration-300 ease-in-out overflow-hidden",
         collapsed ? "w-[68px]" : "w-[260px]",
       )}
     >
@@ -228,7 +228,7 @@ export function Sidebar() {
               <div className="flex items-center gap-3">
                 <Image src="/logo-24.png" alt="dove" width={24} height={24} />
                 <span className="text-lg font-bold tracking-tighter">dove</span>
-                <span className="rounded-md bg-secondary px-1.5 py-0.5 text-[10px] font-medium leading-none text-muted-foreground">
+                <span className="rounded-md bg-secondary px-1.5 py-0.5 text-xs font-medium leading-none text-muted-foreground">
                   v{APP_VERSION}
                 </span>
               </div>

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -25,6 +25,14 @@ import {
   TooltipContent,
 } from "@/components/ui/tooltip";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 
 import type { LucideIcon } from "lucide-react";
 
@@ -199,24 +207,32 @@ export function Sidebar() {
             })}
           </nav>
 
-          {/* User sign out */}
+          {/* User menu */}
           <div className="py-3 flex justify-center w-full">
-            <Tooltip delayDuration={0}>
-              <TooltipTrigger asChild>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
                 <button
-                  onClick={() => signOut({ callbackUrl: "/login" })}
                   className="cursor-pointer hover:ring-2 hover:ring-primary/30 transition-all rounded-full"
+                  aria-label="User menu"
                 >
                   <Avatar className="h-9 w-9">
                     {userImage && <AvatarImage src={userImage} alt={userName} />}
                     <AvatarFallback className="text-xs">{userInitial}</AvatarFallback>
                   </Avatar>
                 </button>
-              </TooltipTrigger>
-              <TooltipContent side="right" sideOffset={8}>
-                {userName} — Sign out
-              </TooltipContent>
-            </Tooltip>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent side="right" align="end" sideOffset={8}>
+                <DropdownMenuLabel>
+                  <p className="text-sm font-medium">{userName}</p>
+                  {userEmail && <p className="text-xs text-muted-foreground">{userEmail}</p>}
+                </DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={() => signOut({ callbackUrl: "/login" })}>
+                  <LogOut className="h-4 w-4" aria-hidden="true" strokeWidth={1.5} />
+                  Sign out
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           </div>
         </div>
       ) : (
@@ -253,26 +269,33 @@ export function Sidebar() {
             ))}
           </nav>
 
-          {/* User info + sign out */}
+          {/* User menu */}
           <div className="px-4 py-3">
-            <div className="flex items-center gap-3">
-              <Avatar className="h-9 w-9 shrink-0">
-                {userImage && <AvatarImage src={userImage} alt={userName} />}
-                <AvatarFallback className="text-xs">{userInitial}</AvatarFallback>
-              </Avatar>
-              <div className="flex-1 min-w-0">
-                <p className="text-sm font-medium text-foreground truncate">{userName}</p>
-                <p className="text-xs text-muted-foreground truncate">{userEmail}</p>
-              </div>
-              <button
-                onClick={() => signOut({ callbackUrl: "/login" })}
-                aria-label="Sign out"
-                title="Sign out"
-                className="flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground hover:text-foreground hover:bg-accent transition-colors shrink-0 cursor-pointer"
-              >
-                <LogOut className="h-4 w-4" aria-hidden="true" strokeWidth={1.5} />
-              </button>
-            </div>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button className="flex w-full items-center gap-3 rounded-lg px-2 py-1.5 hover:bg-accent transition-colors cursor-pointer">
+                  <Avatar className="h-9 w-9 shrink-0">
+                    {userImage && <AvatarImage src={userImage} alt={userName} />}
+                    <AvatarFallback className="text-xs">{userInitial}</AvatarFallback>
+                  </Avatar>
+                  <div className="flex-1 min-w-0 text-left">
+                    <p className="text-sm font-medium text-foreground truncate">{userName}</p>
+                    <p className="text-xs text-muted-foreground truncate">{userEmail}</p>
+                  </div>
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent side="top" align="start" sideOffset={8} className="w-[--radix-dropdown-menu-trigger-width]">
+                <DropdownMenuLabel>
+                  <p className="text-sm font-medium">{userName}</p>
+                  {userEmail && <p className="text-xs text-muted-foreground">{userEmail}</p>}
+                </DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={() => signOut({ callbackUrl: "/login" })}>
+                  <LogOut className="h-4 w-4" aria-hidden="true" strokeWidth={1.5} />
+                  Sign out
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           </div>
         </div>
       )}

--- a/src/components/skeletons.tsx
+++ b/src/components/skeletons.tsx
@@ -60,7 +60,7 @@ export function ProjectsListSkeleton() {
       {Array.from({ length: 6 }).map((_, i) => (
         <div
           key={i}
-          className="rounded-[var(--radius-card)] bg-secondary px-3.5 py-3"
+          className="rounded-[var(--radius-card)] bg-secondary p-4 md:p-5"
         >
           <div className="flex items-center gap-2.5">
             <Skeleton className="h-7 w-7 rounded-md shrink-0" />

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,257 @@
+"use client"
+
+import * as React from "react"
+import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react"
+import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function DropdownMenu({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+}
+
+function DropdownMenuPortal({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
+  return (
+    <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
+  )
+}
+
+function DropdownMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+  return (
+    <DropdownMenuPrimitive.Trigger
+      data-slot="dropdown-menu-trigger"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuContent({
+  className,
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        data-slot="dropdown-menu-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          className
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  )
+}
+
+function DropdownMenuGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
+  return (
+    <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
+  )
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+  inset?: boolean
+  variant?: "default" | "destructive"
+}) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground data-[variant=destructive]:*:[svg]:text-destructive!",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      checked={checked ?? false}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  )
+}
+
+function DropdownMenuRadioGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
+  return (
+    <DropdownMenuPrimitive.RadioGroup
+      data-slot="dropdown-menu-radio-group"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
+  return (
+    <DropdownMenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CircleIcon className="size-2 fill-current" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.RadioItem>
+  )
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.Label
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-2 py-1.5 text-sm font-medium data-[inset]:pl-8",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSub({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
+  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.SubTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[inset]:pl-8 data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto size-4" />
+    </DropdownMenuPrimitive.SubTrigger>
+  )
+}
+
+function DropdownMenuSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+  return (
+    <DropdownMenuPrimitive.SubContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn(
+        "z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuPortal,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+}


### PR DESCRIPTION
## 🥒 babaco design: Color, Typography, Layout & A11y fixes

This PR addresses 4 design issues found during the impeccable design audit:

### Color (#1)
- Dark mode backgrounds now use hue 330 (Sakura brand warmth) instead of neutral gray
- Fixed `hsl()` wrapper on sidebar token — unified to raw HSL values
- Light mode secondary changed from pure white to `330 10% 99%`
- Replaced hardcoded `dark:bg-[#171717]`, `bg-white` with design tokens
- Chart "failed" bar changed from blue to semantic color
- Unified radius tokens to px units

### Typography (#2)
- All page h1 headings now responsive: `text-xl md:text-2xl`
- Eliminated all non-standard font sizes (`text-[9px]`, `text-[10px]`, `text-[11px]`, `text-[13px]`)
- Chart title and template group heading styles improved

### Layout (#3)
- Unified card padding to `p-4 md:p-5`
- AppShell content area padding increased from `px-2 pb-2` to `px-3 pb-3`
- Radius tokens unified to px
- AppShell corner radius uses `--radius-card` token

### Accessibility (#5)
- Send logs table: added ARIA `role="table"`, `role="row"`, `role="cell"` attributes
- Login page: added `aria-hidden` to decorative barcode, improved button accessibility
- Sidebar: replaced direct avatar→logout with DropdownMenu (user info + sign out option)
- Send logs: fixed `<button>` wrapping `<div>` semantic issue

Closes #1, Closes #2, Closes #3, Closes #5
