### PR TITLE
[🥒 babaco] fix: motion & transition improvements

### DIFF
--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -113,7 +113,7 @@ export default function ProjectsPage() {
                         </p>
                       </div>
                     </div>
-                    <ArrowRight className="shrink-0 h-3.5 w-3.5 text-muted-foreground/0 group-hover:text-muted-foreground transition-colors ml-2" strokeWidth={1.5} />
+                    <ArrowRight className="shrink-0 h-3.5 w-3.5 text-muted-foreground/0 group-hover:text-muted-foreground transition-opacity duration-200 ml-2" strokeWidth={1.5} />
                   </div>
 
                   {project.description && (

--- a/src/app/send-logs/page.tsx
+++ b/src/app/send-logs/page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Loader2, Mail, ChevronLeft, ChevronRight, X } from "lucide-react";
 import { toast } from "sonner";
+import { cn } from "@/lib/utils";
 import { AppShell } from "@/components/layout/app-shell";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -294,44 +295,51 @@ export default function SendLogsPage() {
                   </button>
 
                   {/* Expanded detail */}
-                  {expandedId === log.id && (
-                    <div className="mx-4 mb-1 rounded-b-lg border border-t-0 border-border bg-muted/30 px-4 py-3">
-                      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-                        <div>
-                          <span className="text-xs text-muted-foreground block mb-0.5">ID</span>
-                          <span className="text-xs font-mono text-foreground break-all">{log.id}</span>
-                        </div>
-                        {log.resend_id && (
+                  <div
+                    className={cn(
+                      "grid transition-[grid-template-rows] duration-200",
+                      expandedId === log.id ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
+                    )}
+                  >
+                    <div className="overflow-hidden min-h-0">
+                      <div className="mx-4 mb-1 rounded-b-lg border border-t-0 border-border bg-muted/30 px-4 py-3">
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
                           <div>
-                            <span className="text-xs text-muted-foreground block mb-0.5">Resend ID</span>
-                            <span className="text-xs font-mono text-foreground break-all">{log.resend_id}</span>
+                            <span className="text-xs text-muted-foreground block mb-0.5">ID</span>
+                            <span className="text-xs font-mono text-foreground break-all">{log.id}</span>
                           </div>
-                        )}
-                        {log.idempotency_key && (
+                          {log.resend_id && (
+                            <div>
+                              <span className="text-xs text-muted-foreground block mb-0.5">Resend ID</span>
+                              <span className="text-xs font-mono text-foreground break-all">{log.resend_id}</span>
+                            </div>
+                          )}
+                          {log.idempotency_key && (
+                            <div>
+                              <span className="text-xs text-muted-foreground block mb-0.5">Idempotency Key</span>
+                              <span className="text-xs font-mono text-foreground break-all">{log.idempotency_key}</span>
+                            </div>
+                          )}
+                          {log.error_message && (
+                            <div className="md:col-span-2">
+                              <span className="text-xs text-muted-foreground block mb-0.5">Error</span>
+                              <span className="text-xs text-destructive break-all">{log.error_message}</span>
+                            </div>
+                          )}
+                          {log.sent_at && (
+                            <div>
+                              <span className="text-xs text-muted-foreground block mb-0.5">Sent At</span>
+                              <span className="text-xs text-foreground">{formatDate(log.sent_at)}</span>
+                            </div>
+                          )}
                           <div>
-                            <span className="text-xs text-muted-foreground block mb-0.5">Idempotency Key</span>
-                            <span className="text-xs font-mono text-foreground break-all">{log.idempotency_key}</span>
+                            <span className="text-xs text-muted-foreground block mb-0.5">Created</span>
+                            <span className="text-xs text-foreground">{formatDate(log.created_at)}</span>
                           </div>
-                        )}
-                        {log.error_message && (
-                          <div className="md:col-span-2">
-                            <span className="text-xs text-muted-foreground block mb-0.5">Error</span>
-                            <span className="text-xs text-destructive break-all">{log.error_message}</span>
-                          </div>
-                        )}
-                        {log.sent_at && (
-                          <div>
-                            <span className="text-xs text-muted-foreground block mb-0.5">Sent At</span>
-                            <span className="text-xs text-foreground">{formatDate(log.sent_at)}</span>
-                          </div>
-                        )}
-                        <div>
-                          <span className="text-xs text-muted-foreground block mb-0.5">Created</span>
-                          <span className="text-xs text-foreground">{formatDate(log.created_at)}</span>
                         </div>
                       </div>
                     </div>
-                  )}
+                  </div>
                 </div>
               ))}
             </div>

--- a/src/app/templates/page.tsx
+++ b/src/app/templates/page.tsx
@@ -118,7 +118,7 @@ export default function TemplatesPage() {
                     <Link
                       key={t.id}
                       href={`/templates/${t.id}`}
-                      className="flex items-center gap-3 px-4 py-3 hover:bg-muted/30 transition-colors"
+                      className="flex items-center gap-3 px-4 py-3 hover:bg-muted/50 transition-colors duration-150"
                     >
                       <div className="min-w-0 flex-1">
                         <p className="text-sm font-medium text-foreground truncate">{t.name}</p>

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -8,6 +8,7 @@ import { Sidebar } from "./sidebar";
 import { SidebarProvider, useSidebar } from "./sidebar-context";
 import { ThemeToggle } from "./theme-toggle";
 import { Breadcrumbs } from "./breadcrumbs";
+import { cn } from "@/lib/utils";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { TooltipProvider } from "@/components/ui/tooltip";
 
@@ -101,20 +102,27 @@ function AppShellInner({ children, breadcrumbs = [] }: AppShellProps) {
       {!isMobile && <Sidebar />}
 
       {/* Mobile overlay */}
-      {isMobile && mobileOpen && (
+      {isMobile && (
         <>
           <div
-            className="fixed inset-0 z-40 bg-black/50 backdrop-blur-xs"
+            className={cn(
+              "fixed inset-0 z-40 bg-black/50 backdrop-blur-xs transition-opacity duration-300",
+              mobileOpen ? "opacity-100" : "opacity-0 pointer-events-none",
+            )}
             onClick={() => setMobileOpen(false)}
             aria-hidden="true"
           />
           <div
             ref={drawerRef}
             role="dialog"
-            aria-modal="true"
+            aria-modal={mobileOpen}
             aria-label="Navigation menu"
+            aria-hidden={!mobileOpen}
             tabIndex={-1}
-            className="fixed inset-y-0 left-0 z-50 w-[260px] outline-none"
+            className={cn(
+              "fixed inset-y-0 left-0 z-50 w-[260px] outline-none transition-transform duration-300 ease-in-out",
+              mobileOpen ? "translate-x-0" : "-translate-x-full",
+            )}
           >
             <div className="absolute top-3 right-3 z-10">
               <button

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -140,7 +140,7 @@ export function Sidebar() {
   return (
     <aside
       className={cn(
-        "sticky top-0 flex h-screen shrink-0 flex-col bg-background transition-all duration-300 ease-in-out overflow-hidden",
+        "sticky top-0 flex h-screen shrink-0 flex-col bg-background transition-\[width\] duration-300 ease-in-out overflow-hidden",
         collapsed ? "w-[68px]" : "w-[260px]",
       )}
     >


### PR DESCRIPTION
## 🥒 babaco design: Motion & transition improvements

### Motion (#4)
- Mobile sidebar: added fade-in/out overlay + slide-in drawer animation
- Sidebar width: changed `transition-all` → `transition-[width]` for performance
- Project card arrow: added `transition-opacity duration-200`
- Template list hover: increased from `bg-muted/30` → `bg-muted/50` with `transition-colors`
- Send logs: added expand/collapse animation using `grid-template-rows` technique

Closes #4
