### PR TITLE
fix(ui): containers to bg-secondary + radius-card 14px, remove border

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -63,7 +63,7 @@
   --color-chart-5: hsl(var(--chart-5));
 
   /* Radius tokens — unified to px */
-  --radius-card: 16px;
+  --radius-card: 14px;
   --radius-widget: 10px;
   --radius-lg: 12px;
   --radius-md: 10px;

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -465,7 +465,7 @@ export default function ProjectDetailPage({
             {showAddRecipient && (
               <form
                 onSubmit={(e) => void handleAddRecipient(e)}
-                className="flex flex-col gap-3 rounded-lg border border-border bg-muted/20 p-3"
+                className="flex flex-col gap-3 rounded-[var(--radius-widget)] bg-muted/20 p-3"
               >
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                   <Input
@@ -504,12 +504,12 @@ export default function ProjectDetailPage({
             )}
 
             {recipients.length === 0 ? (
-              <div className="rounded-lg border border-border bg-background/50 p-6 text-center">
+              <div className="rounded-[var(--radius-card)] bg-secondary p-6 text-center">
                 <Users className="h-8 w-8 text-muted-foreground/40 mx-auto mb-2" strokeWidth={1.5} />
                 <p className="text-xs text-muted-foreground">No recipients yet. Add one to start sending emails.</p>
               </div>
             ) : (
-              <div className="divide-y divide-border rounded-lg border border-border">
+              <div className="rounded-[var(--radius-card)] bg-secondary p-1 overflow-x-auto">
                 {recipients.map((r) => (
                   <div key={r.id} className="flex items-center gap-3 px-3 py-2.5">
                     <div className="min-w-0 flex-1">
@@ -558,12 +558,12 @@ export default function ProjectDetailPage({
           </CardHeader>
           <CardContent>
             {templates.length === 0 ? (
-              <div className="rounded-lg border border-border bg-background/50 p-6 text-center">
+              <div className="rounded-[var(--radius-card)] bg-secondary p-6 text-center">
                 <FileText className="h-8 w-8 text-muted-foreground/40 mx-auto mb-2" strokeWidth={1.5} />
                 <p className="text-xs text-muted-foreground">No templates yet.</p>
               </div>
             ) : (
-              <div className="divide-y divide-border rounded-lg border border-border">
+              <div className="rounded-[var(--radius-card)] bg-secondary p-1 overflow-x-auto">
                 {templates.map((t) => (
                   <Link
                     key={t.id}

--- a/src/app/templates/[id]/page.tsx
+++ b/src/app/templates/[id]/page.tsx
@@ -334,7 +334,7 @@ export default function TemplateDetailPage({
                   </p>
                 ) : (
                   variables.map((v, i) => (
-                    <div key={i} className="flex items-start gap-2 rounded-lg border border-border bg-muted/20 p-2.5">
+                    <div key={i} className="flex items-start gap-2 rounded-[var(--radius-widget)] bg-muted/20 p-2.5">
                       <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 flex-1">
                         <Input
                           placeholder="name"
@@ -487,7 +487,7 @@ export default function TemplateDetailPage({
                   />
                 </div>
               ) : (
-                <div className="flex items-center justify-center py-8 rounded-lg border border-dashed border-border">
+                <div className="flex items-center justify-center py-8 rounded-[var(--radius-card)] bg-secondary">
                   <p className="text-xs text-muted-foreground">
                     Click &quot;Render&quot; to preview the template.
                   </p>

--- a/src/app/templates/new/page.tsx
+++ b/src/app/templates/new/page.tsx
@@ -217,7 +217,7 @@ function NewTemplateForm() {
           </div>
 
           {variables.map((v, i) => (
-            <div key={i} className="flex items-start gap-2 rounded-lg border border-border bg-muted/20 p-3">
+            <div key={i} className="flex items-start gap-2 rounded-[var(--radius-widget)] bg-muted/20 p-3">
               <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 flex-1">
                 <Input
                   placeholder="name"

--- a/src/components/skeletons.tsx
+++ b/src/components/skeletons.tsx
@@ -126,7 +126,7 @@ export function ProjectDetailSkeleton() {
 
       {/* Recipients card */}
       <CardSkeleton>
-        <div className="divide-y divide-border rounded-lg border border-border">
+        <div className="rounded-[var(--radius-card)] bg-secondary p-1 overflow-x-auto">
           {Array.from({ length: 2 }).map((_, i) => (
             <div key={i} className="flex items-center justify-between px-3 py-2.5">
               <div className="space-y-1">
@@ -141,7 +141,7 @@ export function ProjectDetailSkeleton() {
 
       {/* Templates card */}
       <CardSkeleton>
-        <div className="divide-y divide-border rounded-lg border border-border">
+        <div className="rounded-[var(--radius-card)] bg-secondary p-1 overflow-x-auto">
           {Array.from({ length: 2 }).map((_, i) => (
             <div key={i} className="flex items-center justify-between px-3 py-2.5">
               <div className="space-y-1">


### PR DESCRIPTION
Closes #9

- `--radius-card: 16px` → `14px`
- List containers: `rounded-lg border border-border` → `rounded-[var(--radius-card)] bg-secondary p-1`
- Empty states: border → `bg-secondary rounded-card`
- Variable items: remove border, keep `bg-muted/20`