### PR TITLE
fix(ui): remove shadow from mobile close button

### DIFF
--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -129,7 +129,7 @@ function AppShellInner({ children, breadcrumbs = [] }: AppShellProps) {
                 type="button"
                 onClick={() => setMobileOpen(false)}
                 aria-label="Close navigation"
-                className="flex h-8 w-8 items-center justify-center rounded-lg bg-background/80 text-muted-foreground shadow-sm backdrop-blur-sm transition-colors hover:bg-background hover:text-foreground"
+                className="flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
               >
                 <X className="h-4 w-4" aria-hidden="true" strokeWidth={1.5} />
               </button>


### PR DESCRIPTION
Closes #10

Remove `shadow-sm`, `backdrop-blur-sm`, `bg-background/80` from mobile sidebar close button. Use standard ghost button hover.