### PR TITLE
fix(ui): chart tooltip to bg-secondary without border/shadow

### DIFF
--- a/src/components/charts/sends-chart.tsx
+++ b/src/components/charts/sends-chart.tsx
@@ -28,7 +28,7 @@ function CustomTooltip({
   if (!active || !payload?.length) return null;
 
   return (
-    <div className="rounded-lg border border-border bg-background px-3 py-2 shadow-md">
+    <div className="rounded-[var(--radius-widget)] bg-secondary px-3 py-2">
       <p className="text-sm font-medium text-foreground mb-1">{label}</p>
       {payload.map((entry) => (
         <p key={entry.dataKey} className="text-xs text-muted-foreground">

--- a/src/components/charts/sends-chart.tsx
+++ b/src/components/charts/sends-chart.tsx
@@ -28,7 +28,7 @@ function CustomTooltip({
   if (!active || !payload?.length) return null;
 
   return (
-    <div className="rounded-[var(--radius-widget)] bg-secondary px-3 py-2">
+    <div className="rounded-[var(--radius-widget)] bg-secondary px-3 py-2 shadow-sm">
       <p className="text-sm font-medium text-foreground mb-1">{label}</p>
       {payload.map((entry) => (
         <p key={entry.dataKey} className="text-xs text-muted-foreground">


### PR DESCRIPTION
Closes #11

Chart tooltip: `rounded-lg border bg-background shadow-md` → `rounded-[var(--radius-widget)] bg-secondary`.