### PR TITLE
fix(ui): skeleton background from bg-accent to bg-muted

### DIFF
--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -4,7 +4,7 @@ function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="skeleton"
-      className={cn("animate-pulse rounded-md bg-accent", className)}
+      className={cn("animate-pulse rounded-md bg-muted", className)}
       {...props}
     />
   )


### PR DESCRIPTION
Closes #13

Skeleton base component: `bg-accent` → `bg-muted` per B04-1 spec.