### PR TITLE
fix(ui): align bg-card usage to B05 luminance spec

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -43,7 +43,7 @@ function StatsCard({
           <p className="text-xs md:text-sm text-muted-foreground">{label}</p>
           <p className="text-2xl md:text-3xl font-semibold font-display text-foreground tracking-tight tabular-nums">{value}</p>
         </div>
-        <div className={`rounded-md ${accent ?? "bg-card"} p-2`}>
+        <div className={`rounded-md ${accent ?? "bg-background"} p-2`}>
           <Icon className={`h-5 w-5 ${accent ? "text-current" : "text-muted-foreground"}`} />
         </div>
       </div>

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -103,7 +103,7 @@ export default function ProjectsPage() {
                 >
                   <div className="flex items-center justify-between">
                     <div className="flex items-center gap-2.5 min-w-0">
-                      <div className="shrink-0 rounded-md bg-card p-1.5">
+                      <div className="shrink-0 rounded-md bg-background p-1.5">
                         <Mail className="h-4 w-4 text-muted-foreground" strokeWidth={1.5} />
                       </div>
                       <div className="min-w-0">


### PR DESCRIPTION
Closes #29\n\nReplace misused bg-card (L1) with bg-secondary (L2) for content cards inside the floating island, per Basalt B05 spec.