### PR TITLE
ci: upgrade base-ci to v2026.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   # L1 + G1 + G2 — Core quality gate from base-ci
   # ─────────────────────────────────────────────────────
   quality:
-    uses: nocoo/base-ci/.github/workflows/bun-quality.yml@v2026
+    uses: nocoo/base-ci/.github/workflows/bun-quality.yml@v2026.1
     with:
       pre-command: "bun run build"
       test-command: "bun run test:coverage"


### PR DESCRIPTION
Upgrade base-ci reference from `@v2026` to `@v2026.1` to align with all other repos.