### PR TITLE
chore: align coverage config with pew best practices

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,21 +15,35 @@ export default defineConfig({
     },
     coverage: {
       provider: "v8",
+      // AST-aware remapping is built into vitest v4+; no opt-in needed.
       reporter: ["text", "json"],
       skipFull: true,
       include: ["src/lib/**/*.ts", "src/server/lib/**/*.ts", "src/server/routes/**/*.ts", "src/server/middleware/**/*.ts", "src/server/index.ts"],
       exclude: [
+        // Third-party dependencies — never our code to cover.
         "node_modules/",
+        // Test files themselves are not subject to coverage.
         "**/*.test.ts",
         "**/*.spec.ts",
+        // Build/tool configuration files contain no runtime logic worth covering.
         "**/*.config.*",
+        // Type declaration files have no executable code.
         "**/*.d.ts",
+        // Test fixtures, mocks, and helpers — exercised indirectly by tests.
         "src/__tests__/",
         "src/server/__tests__/",
+        /*
+         * Client-side code (UI layer) is covered by Playwright E2E tests
+         * under e2e/ rather than vitest unit tests.
+         */
         "src/client/",
         "src/components/",
         "src/hooks/",
         "src/routes/",
+        /*
+         * db-init.ts is a one-shot bootstrap script run manually during
+         * deployment; covered by integration smoke tests in e2e/.
+         */
         "src/server/routes/db-init.ts",
       ],
       thresholds: {


### PR DESCRIPTION
Align vitest coverage configuration with pew best practices:\n\n- Add exclude comments explaining why each entry is excluded\n- Add v4 AST-aware remapping comment (or experimentalAstAwareRemapping for v3)\n- Ensure reporter config is present\n- Threshold values unchanged