### PR TITLE
chore(deps): bump @cloudflare/workers-types 4.20260610.1 → 4.20260611.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20260610.1",
+        "@cloudflare/workers-types": "^4.20260611.1",
         "@happy-dom/global-registrator": "^20.10.2",
         "@playwright/test": "^1.60.0",
         "@tailwindcss/postcss": "^4.3.0",
@@ -85,7 +85,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260603.1", "", { "os": "win32", "cpu": "x64" }, "sha512-DvwqkXMAJRPoDN4PxapAwhlz/6ouD+6R1ttbAEK3cWD/QBvFF5STx7Ds/9Irf+rBly3np3uHWkeX+wZnNFEuzA=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260610.1", "", {}, "sha512-Mk/f3lUygeIHzQ4HnJjU/JvGg/kllgp9gISty9nylHE/2M2MFeKO+hgAKSgiPpmwUbuhewdYGgqFGgT/ADK0/g=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260611.1", "", {}, "sha512-DLiz8Ol1OIWLigJ+dGvuQ5Nm66D/CHNPasl8YnPiz6fGo10ggYSIVuEDMlFk6oho+piAHstNmZMl088w8xqW6g=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20260610.1",
+    "@cloudflare/workers-types": "^4.20260611.1",
     "@happy-dom/global-registrator": "^20.10.2",
     "@playwright/test": "^1.60.0",
     "@tailwindcss/postcss": "^4.3.0",


### PR DESCRIPTION
## Summary

Single-commit dependency bump: `@cloudflare/workers-types` `^4.20260610.1` → `^4.20260611.1` (devDep, used by `src/server/env.ts`).

### Why this PR is types-only

The original batch also intended to bump `wrangler` `4.98.0` → `4.100.0` (GH #93). That bump was held back: against the current `wrangler.toml` + `dist/client`, local probing shows wrangler 4.100.0 still reproduces the SPA root regression first observed on 4.99.0 (see PR #91 description):

| wrangler | `GET /` | `GET /api/live` | `GET /projects` |
|---|---|---|---|
| 4.98.0 ✅ | 200 + `index.html` SPA shell | 200 | 200 |
| 4.100.0 ❌ | 500 + `{"error":"Server misconfiguration"}` | 200 | 200 |

Under 4.100.0, root `/` no longer routes through `[assets]` `not_found_handling = "single-page-application"` — it falls through to the Worker and lands at the misconfig branch in `src/server/middleware/auth-session.ts`. Non-root paths still serve assets correctly. The regression is identical in shape to the 4.99 one called out in #91, just unfixed in 4.100. GH #93 is being left open with a note; we will revisit when a wrangler release restores SPA root handling.

## Test plan

- [x] `bun install --frozen-lockfile`
- [x] `bun run typecheck` (0 errors)
- [x] `bun run lint` (0 errors, 0 warnings)
- [x] `bun run test:coverage` (442/442; coverage 99.89% / 96.73% / 100% / 99.89%)
- [x] `bun run test:e2e:api` (L2 74/74 — ran in pre-push)
- [x] `bun run gate:deps` (osv-scanner clean — ran in pre-push)
- [ ] `bun run test:e2e:bdd` (L3 — on-demand only; not run locally, CI will exercise SPA-affecting flows)

Closes #92