### PR TITLE
chore(deps): bump @cloudflare/workers-types 4.20260612.1 → 4.20260613.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20260612.1",
+        "@cloudflare/workers-types": "^4.20260613.1",
         "@happy-dom/global-registrator": "^20.10.3",
         "@playwright/test": "^1.60.0",
         "@tailwindcss/postcss": "^4.3.1",
@@ -86,7 +86,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260603.1", "", { "os": "win32", "cpu": "x64" }, "sha512-DvwqkXMAJRPoDN4PxapAwhlz/6ouD+6R1ttbAEK3cWD/QBvFF5STx7Ds/9Irf+rBly3np3uHWkeX+wZnNFEuzA=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260612.1", "", {}, "sha512-PMQI7XP/wrMhxyjseUHoHj6XFqkHaf4utWQ/hhefVY8oMK2LJ730oeQ7H/nZSVMexZe39DzsdOx7sf1PqMr7+Q=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260613.1", "", {}, "sha512-1mrgjE6epolwBhroeGAp5ud5H6Vyi6tl1o/NP0T4rXJ8bmEjmhHnbCzAhHTDHV0PIeip43wcuzHKJarvaGTaUA=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20260612.1",
+    "@cloudflare/workers-types": "^4.20260613.1",
     "@happy-dom/global-registrator": "^20.10.3",
     "@playwright/test": "^1.60.0",
     "@tailwindcss/postcss": "^4.3.1",


### PR DESCRIPTION
## Summary

Single-commit dep bump for choko issue #104. Independent of the held wrangler #93 blocker.

## Commit

- `ed6cd70` chore(deps): bump @cloudflare/workers-types 4.20260612.1 → 4.20260613.1

## Verification

- `bun run typecheck` ✅ 0 errors
- `bun run lint` ✅ 0 warnings
- `bun run test:coverage` ✅ 99.89% stmts / 96.73% branches / 100% funcs / 99.89% lines
- `bun run build` ✅
- `bun run gate:security` ✅ (pre-push)
- L2 API E2E ✅ 74/74 (pre-push)

## Out of scope

- **#93 (wrangler 4.98 → 4.100)** remains held under the SPA root 500 regression blocker.

Closes #104