### PR TITLE
chore(deps): bump @cloudflare/workers-types 4.20260620.1 → 4.20260621.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,14 +24,14 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20260620.1",
+        "@cloudflare/workers-types": "^4.20260621.1",
         "@happy-dom/global-registrator": "^20.10.6",
         "@playwright/test": "^1.61.0",
         "@tailwindcss/postcss": "^4.3.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
         "@types/bun": "^1.3.14",
-        "@types/node": "26.0.0",
+        "@types/node": "^26.0.0",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.2",
@@ -87,7 +87,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260617.1", "", { "os": "win32", "cpu": "x64" }, "sha512-rgBV9wQrv0OSKgCTTbhFUFY3sLGNANZ88aqaLvtmEn2gmbFVb1J4PDGochVUdB7NSEp4D/ghHva6/8SZmbONpw=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260620.1", "", {}, "sha512-WB81w9u1bAS7KcekpC7/nYhLpIXAEtgybso7XgGJV8CQKNkNPYcyjvICLdghOlDBi/9Ivk+f7NRckV2Bkq1bDg=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260621.1", "", {}, "sha512-c4xrf4shZdDOK1ihh1UKzlS/3MDYiGThT/Oqr4Y3qR9NLCSNzHB7rt+Vk/LOp0ZSNjA+7WNJEQsOhpiQtpT2GA=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20260620.1",
+    "@cloudflare/workers-types": "^4.20260621.1",
     "@happy-dom/global-registrator": "^20.10.6",
     "@playwright/test": "^1.61.0",
     "@tailwindcss/postcss": "^4.3.1",


### PR DESCRIPTION
## Summary

- Bump `@cloudflare/workers-types` `^4.20260620.1` → `^4.20260621.1` (devDependencies, patch range preserved).

## Checks

- `bun run typecheck` ✅
- `bun run lint` ✅
- `bun run test:coverage` ✅ (99.89% stmts)
- `bun run test:e2e:api` ✅ (74 pass, 0 fail)
- `bun run gate:deps` ✅ (osv-scanner clean)

Closes nocoo/dove#139
