### PR TITLE
chore(deps): bump @types/node 26.0.0 → 26.0.1, nanoid 5.1.15 → 5.1.16

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
         "jose": "^6.2.3",
         "lucide-react": "^1.21.0",
         "marked": "^18.0.5",
-        "nanoid": "^5.1.15",
+        "nanoid": "^5.1.16",
         "postcss": "^8.5.15",
         "radix-ui": "^1.6.0",
         "react": "19.2.7",
@@ -31,7 +31,7 @@
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
         "@types/bun": "^1.3.14",
-        "@types/node": "26.0.1",
+        "@types/node": "^26.0.1",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.3",
@@ -791,7 +791,7 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "nanoid": ["nanoid@5.1.15", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-kBg3RpGtIe+RpTbyXwoI6pk5yD7KUiI3sygUqgeBMRst42KmhB4RZC7eiO9Wa1HIpaCCtpE2DJ6OI4Wi5ebwFw=="],
+    "nanoid": ["nanoid@5.1.16", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -31,7 +31,7 @@
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
         "@types/bun": "^1.3.14",
-        "@types/node": "^26.0.0",
+        "@types/node": "26.0.1",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.3",
@@ -487,7 +487,7 @@
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
-    "@types/node": ["@types/node@26.0.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA=="],
+    "@types/node": ["@types/node@26.0.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw=="],
 
     "@types/react": ["@types/react@19.2.17", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw=="],
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "jose": "^6.2.3",
     "lucide-react": "^1.21.0",
     "marked": "^18.0.5",
-    "nanoid": "^5.1.15",
+    "nanoid": "^5.1.16",
     "postcss": "^8.5.15",
     "radix-ui": "^1.6.0",
     "react": "19.2.7",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
     "@types/bun": "^1.3.14",
-    "@types/node": "^26.0.0",
+    "@types/node": "^26.0.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.3",


### PR DESCRIPTION
## Summary

Patch-level dependency batch for 2026-06-25:

- `@types/node` 26.0.0 → 26.0.1 (devDependency, closes #151)
- `nanoid` 5.1.15 → 5.1.16 (dependency, closes #152)

Each upgrade is its own atomic commit. Clean reinstall (`rm -rf node_modules .next && bun install`) performed between commits per the issue's upgrade step to avoid `.bun` cache staleness.

## Verification

- ✅ `tsc --noEmit`
- ✅ `eslint` (lint-staged)
- ✅ `gitleaks` secret scan
- ✅ Route / page coverage gates
- ✅ `vitest run --coverage` — 442 tests, 99.89% statements
- ✅ `osv-scanner` (pre-push)
- ✅ L2 API E2E — 74 tests passed

Closes #151
Closes #152
