### PR TITLE
chore(deps): upgrade dependencies (batch 2026-06-28)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20260626.1",
+        "@cloudflare/workers-types": "^4.20260628.1",
         "@happy-dom/global-registrator": "^20.10.6",
         "@playwright/test": "^1.61.1",
         "@tailwindcss/postcss": "^4.3.1",
@@ -87,7 +87,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260625.1", "", { "os": "win32", "cpu": "x64" }, "sha512-LH6iIX1HHaTwVKV5VokDxxUErXJzQoNZFRwVm7Vx/3fB/ApcTcRCUaMqcxI4as94jEUqg+pmX5czOndiveohow=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260626.1", "", {}, "sha512-fBnpQyFRS3Ce1l2IUd3k+aUxgy/7VMlVXF4F672/eSrpXFeezCy3Ha6Z2uTyGgqu9sGvQPOj8nqKBv2yeI+ciw=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260628.1", "", {}, "sha512-fMy5zBnNl/PxGqDzSOQb1TdqyR1sRT1Z7T4F8/cqtxpZ1w8VkejWi0qUH7GZE0I2gJyapdP0oW4pNZfxUbekmw=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
         "lucide-react": "^1.22.0",
         "marked": "^18.0.5",
         "nanoid": "^5.1.16",
-        "postcss": "^8.5.15",
+        "postcss": "^8.5.16",
         "radix-ui": "^1.6.0",
         "react": "19.2.7",
         "react-dom": "19.2.7",
@@ -52,7 +52,7 @@
   "overrides": {
     "brace-expansion": "^5.0.6",
     "esbuild": "^0.28.1",
-    "postcss": "^8.5.15",
+    "postcss": "^8.5.16",
     "undici": "^7.28.0",
     "ws": "^8.20.1",
   },
@@ -821,7 +821,7 @@
 
     "playwright-core": ["playwright-core@1.61.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg=="],
 
-    "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
+    "postcss": ["postcss@8.5.16", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "entities": "^8.0.0",
         "hono": "^4.12.27",
         "jose": "^6.2.3",
-        "lucide-react": "^1.21.0",
+        "lucide-react": "^1.22.0",
         "marked": "^18.0.5",
         "nanoid": "^5.1.16",
         "postcss": "^8.5.15",
@@ -771,7 +771,7 @@
 
     "log-update": ["log-update@6.1.0", "", { "dependencies": { "ansi-escapes": "^7.0.0", "cli-cursor": "^5.0.0", "slice-ansi": "^7.1.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w=="],
 
-    "lucide-react": ["lucide-react@1.21.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-reEZMXq8Qdd5jg5XYkQ5TR1fB/GiQ7ih4vcrthYDtgjSDwh0i6/YLiGjsWsIwgN49gpAnd4J2elSNzncMEEUUQ=="],
+    "lucide-react": ["lucide-react@1.22.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-c9o3l0PiNcgOQDW4F31BEYHudE7kgxVt3o30qMl36ZPwTxXlGB4QnLilhERvVM4uh/pl5MDyY1/gzZSYcHDtBg=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lucide-react": "^1.22.0",
     "marked": "^18.0.5",
     "nanoid": "^5.1.16",
-    "postcss": "^8.5.15",
+    "postcss": "^8.5.16",
     "radix-ui": "^1.6.0",
     "react": "19.2.7",
     "react-dom": "19.2.7",
@@ -66,7 +66,7 @@
     "wrangler": "^4.105.0"
   },
   "overrides": {
-    "postcss": "^8.5.15",
+    "postcss": "^8.5.16",
     "brace-expansion": "^5.0.6",
     "ws": "^8.20.1",
     "esbuild": "^0.28.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "entities": "^8.0.0",
     "hono": "^4.12.27",
     "jose": "^6.2.3",
-    "lucide-react": "^1.21.0",
+    "lucide-react": "^1.22.0",
     "marked": "^18.0.5",
     "nanoid": "^5.1.16",
     "postcss": "^8.5.15",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20260626.1",
+    "@cloudflare/workers-types": "^4.20260628.1",
     "@happy-dom/global-registrator": "^20.10.6",
     "@playwright/test": "^1.61.1",
     "@tailwindcss/postcss": "^4.3.1",


### PR DESCRIPTION
## Summary

依赖升级批次 2026-06-28，对应 STU-1385：

- `@cloudflare/workers-types` 4.20260626.1 → 4.20260628.1 (devDependency, GH #162)
- `lucide-react` 1.21.0 → 1.22.0 (dependency, GH #163)
- `postcss` 8.5.15 → 8.5.16 (dependency + `overrides.postcss`, GH #164)

每项一个原子 commit，caret range 全部保留（参考 fd81ad0 策略）。postcss 同时改 `overrides.postcss` 以让 lockfile 真正解析到 8.5.16；其余包仅改 specifier + resolved 版本/integrity。

Closes nocoo/dove#162
Closes nocoo/dove#163
Closes nocoo/dove#164

## Test plan

本地全量验证均通过：

- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test` (442/442)
- [x] `bun run build`
- [x] `bun run gate:security` (gitleaks + osv-scanner)
- [x] `bun run gate:deps`
- [x] pre-push hook (`test:e2e:api` 74/74 + `gate:deps`)
- [x] Reviewer-02 已审 (Multica STU-1385) — `bun install --frozen-lockfile` 可复现解析结果
