### PR TITLE
chore: add root .npmrc for supply chain security baseline

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,21 @@
+# ===== Supply chain security =====
+# Pin to official npm registry (防钓鱼源)
+registry=https://registry.npmjs.org/
+
+# ===== Lockfile integrity =====
+# Pin exact versions on npm install (防 minor/patch 漂移)
+save-exact=true
+# Always maintain package-lock (防 lockfile 被删)
+package-lock=true
+
+# ===== Environment consistency =====
+# Enforce engines field (防 Node/npm 版本不匹配)
+engine-strict=true
+
+# ===== Audit strategy =====
+# Auto-run audit on install
+audit=true
+# Fail install on high+ severity
+audit-level=high
+# Silence funding output (noise reduction)
+fund=false


### PR DESCRIPTION
chore: add root .npmrc for supply chain security baseline

Pin registry to official npm, enable audit (level=high), enforce
lockfile integrity (save-exact + package-lock) and engine-strict
to prevent phishing sources, dep drift, and Node/npm mismatches.

Closes STU-1539.
