### PR TITLE
chore(deps): bump postcss 8.5.17 + @cloudflare/workers-types 5.20260711.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "5.20260710.1",
+        "@cloudflare/workers-types": "5.20260711.1",
         "@happy-dom/global-registrator": "^20.10.6",
         "@playwright/test": "^1.61.1",
         "@tailwindcss/postcss": "^4.3.2",
@@ -87,7 +87,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260708.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bC/aSAwLy16Vjo24i9XU3aWH+eRgz7NeR5xPKavGbembO18ZywYTQbXh14eXtY6fAqN3RzRG8psijTdhX4xydA=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260710.1", "", {}, "sha512-4ooaY2Pb5XGwDn8Fzm6jnTAJkIX0R5LBvL9euQpp2T58sQItlAQd9yivAlkwGhpY5cM1u81/9HaXwKAjXwtyzA=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260711.1", "", {}, "sha512-yY6GXfyrHJa33EWaSzS5N56Lsll02kgHo4Qodz2l2DNl4L6L5yXBMZVMvcYArirdYA1xn+o8LKVRQGdRpmSMzA=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
         "lucide-react": "1.24.0",
         "marked": "18.0.6",
         "nanoid": "^5.1.16",
-        "postcss": "^8.5.16",
+        "postcss": "^8.5.17",
         "radix-ui": "^1.6.2",
         "react": "19.2.7",
         "react-dom": "19.2.7",
@@ -52,7 +52,7 @@
   "overrides": {
     "brace-expansion": "^5.0.6",
     "esbuild": "^0.28.1",
-    "postcss": "^8.5.16",
+    "postcss": "^8.5.17",
     "undici": "^7.28.0",
     "ws": "^8.20.1",
   },
@@ -821,7 +821,7 @@
 
     "playwright-core": ["playwright-core@1.61.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg=="],
 
-    "postcss": ["postcss@8.5.16", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg=="],
+    "postcss": ["postcss@8.5.17", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-J7EF+8X+CzRPaJPOv9Ck2wNWJvGnnl3PcNPAdGg6GTLjyVpyQ0yATMSXRFRV01BviT/9Gwuc3rjEyJbDJG9a4w=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lucide-react": "1.24.0",
     "marked": "18.0.6",
     "nanoid": "^5.1.16",
-    "postcss": "^8.5.16",
+    "postcss": "^8.5.17",
     "radix-ui": "^1.6.2",
     "react": "19.2.7",
     "react-dom": "19.2.7",
@@ -66,7 +66,7 @@
     "wrangler": "4.110.0"
   },
   "overrides": {
-    "postcss": "^8.5.16",
+    "postcss": "^8.5.17",
     "brace-expansion": "^5.0.6",
     "ws": "^8.20.1",
     "esbuild": "^0.28.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "5.20260710.1",
+    "@cloudflare/workers-types": "5.20260711.1",
     "@happy-dom/global-registrator": "^20.10.6",
     "@playwright/test": "^1.61.1",
     "@tailwindcss/postcss": "^4.3.2",


### PR DESCRIPTION
## Summary

- `postcss` `8.5.16` → `8.5.17` (closes #215)
- `@cloudflare/workers-types` `5.20260710.1` → `5.20260711.1` (closes #214)

两个 patch bump 分别独立提交，便于回滚。跟踪 issue [STU-1808](https://multica.example/issue/7a063b26-a3e1-44cd-898b-f9dc4972452e)（同批 #202 TypeScript 6→7 仍受上游 `typescript-eslint` peer `<6.1.0` 阻塞，沿用 STU-1729 blocked 结论，未在本 PR 处理）。

## Test plan

本地全套 gate 均绿：

- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test` — 442/442 passed
- [x] `bun run build`
- [x] `bun run gate:deps` (osv-scanner)
- [x] `bun run gate:secrets` (gitleaks)
- [x] `bun run test:e2e:api` — 74/74 passed (pre-push hook)

Closes #214
Closes #215
