### PR TITLE
chore(deps): batch bump hono, workers-types, postcss (2026-07-13)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,12 +8,12 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "entities": "^8.0.0",
-        "hono": "^4.12.29",
+        "hono": "^4.12.30",
         "jose": "^6.2.3",
         "lucide-react": "1.24.0",
         "marked": "18.0.6",
         "nanoid": "^5.1.16",
-        "postcss": "^8.5.17",
+        "postcss": "^8.5.18",
         "radix-ui": "^1.6.2",
         "react": "19.2.7",
         "react-dom": "19.2.7",
@@ -24,7 +24,7 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "5.20260711.1",
+        "@cloudflare/workers-types": "5.20260712.1",
         "@happy-dom/global-registrator": "^20.10.6",
         "@playwright/test": "^1.61.1",
         "@tailwindcss/postcss": "^4.3.2",
@@ -52,7 +52,7 @@
   "overrides": {
     "brace-expansion": "^5.0.6",
     "esbuild": "^0.28.1",
-    "postcss": "^8.5.17",
+    "postcss": "^8.5.18",
     "undici": "^7.28.0",
     "ws": "^8.20.1",
   },
@@ -87,7 +87,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260708.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bC/aSAwLy16Vjo24i9XU3aWH+eRgz7NeR5xPKavGbembO18ZywYTQbXh14eXtY6fAqN3RzRG8psijTdhX4xydA=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260711.1", "", {}, "sha512-yY6GXfyrHJa33EWaSzS5N56Lsll02kgHo4Qodz2l2DNl4L6L5yXBMZVMvcYArirdYA1xn+o8LKVRQGdRpmSMzA=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260712.1", "", {}, "sha512-tkQ18Lz41EPXLzh4cSuIGQzztDVueuGfTcjlP4M7Qa0rfHpVBNItf3GRkd9O0JgiXs9csAwz/kVv7sjYXSoF2w=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 
@@ -693,7 +693,7 @@
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
-    "hono": ["hono@4.12.29", "", {}, "sha512-1hNiRjawYrLq/4m3DQQjPGFg0VZkk4RjQJDff/excI6Dm9BiL75qxGrd7/c6YOxPdq6AscP3LiXhQ6fKFC1Waw=="],
+    "hono": ["hono@4.12.30", "", {}, "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog=="],
 
     "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
 
@@ -821,7 +821,7 @@
 
     "playwright-core": ["playwright-core@1.61.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg=="],
 
-    "postcss": ["postcss@8.5.17", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-J7EF+8X+CzRPaJPOv9Ck2wNWJvGnnl3PcNPAdGg6GTLjyVpyQ0yATMSXRFRV01BviT/9Gwuc3rjEyJbDJG9a4w=="],
+    "postcss": ["postcss@8.5.18", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 

--- a/package.json
+++ b/package.json
@@ -26,12 +26,12 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "entities": "^8.0.0",
-    "hono": "^4.12.29",
+    "hono": "^4.12.30",
     "jose": "^6.2.3",
     "lucide-react": "1.24.0",
     "marked": "18.0.6",
     "nanoid": "^5.1.16",
-    "postcss": "^8.5.17",
+    "postcss": "^8.5.18",
     "radix-ui": "^1.6.2",
     "react": "19.2.7",
     "react-dom": "19.2.7",
@@ -42,7 +42,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "5.20260711.1",
+    "@cloudflare/workers-types": "5.20260712.1",
     "@happy-dom/global-registrator": "^20.10.6",
     "@playwright/test": "^1.61.1",
     "@tailwindcss/postcss": "^4.3.2",
@@ -66,7 +66,7 @@
     "wrangler": "4.110.0"
   },
   "overrides": {
-    "postcss": "^8.5.17",
+    "postcss": "^8.5.18",
     "brace-expansion": "^5.0.6",
     "ws": "^8.20.1",
     "esbuild": "^0.28.1",


### PR DESCRIPTION
## Summary

Batch minor/patch dependency bumps.

- hono `4.12.29` → `4.12.30` — Closes #218 (patch)
- @cloudflare/workers-types `5.20260711.1` → `5.20260712.1` — Closes #217 (minor)
- postcss `8.5.17` → `8.5.18` — Closes #220 (patch)

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint` (eslint --max-warnings=0)
- [x] `bun run test` — 36 files / 442 tests
- [x] `bun run test:coverage` — 99.89% stmts / 96.73% branches / 100% funcs / 99.89% lines
- [x] `bun run build`
- [x] `bun run gate:security`
- [x] `bun run test:e2e:api` (pre-push L2, 74 tests pass)