### PR TITLE
chore(deps): bump nanoid 5.1.16 → 6.0.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
         "jose": "^6.2.3",
         "lucide-react": "1.24.0",
         "marked": "18.0.6",
-        "nanoid": "^5.1.16",
+        "nanoid": "^6.0.0",
         "postcss": "^8.5.18",
         "radix-ui": "^1.6.2",
         "react": "19.2.7",
@@ -791,7 +791,7 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "nanoid": ["nanoid@5.1.16", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ=="],
+    "nanoid": ["nanoid@6.0.0", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-mkUH+rPkwU2qPadJ0oJZOjeZ5Mxn8Q1UhevwkTRWNuUZzyia3h4rhzK39hxaHTk0o2OxB8W2SQ6A8k23ZDi1pQ=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "jose": "^6.2.3",
     "lucide-react": "1.24.0",
     "marked": "18.0.6",
-    "nanoid": "^5.1.16",
+    "nanoid": "^6.0.0",
     "postcss": "^8.5.18",
     "radix-ui": "^1.6.2",
     "react": "19.2.7",


### PR DESCRIPTION
## Summary

MAJOR bump — Closes #219.

Only breaking change in `nanoid@6.0.0` is dropping Node 18/20 support. This project runs on Cloudflare Workers (Web Crypto) with Node 26 locally, so no runtime impact. API surface (`nanoid()`, `nanoid(size)`) is unchanged; `src/lib/id.ts` needs no code changes.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint` (eslint --max-warnings=0)
- [x] `bun run test` — 36 files / 442 tests
- [x] `bun run test:coverage` — 99.89% stmts / 96.73% branches / 100% funcs / 99.89% lines
- [x] `bun run build`
- [x] `bun run gate:security`
- [x] `bun run test:e2e:api` (pre-push L2, 74 tests pass)
- [x] `wrangler deploy --dry-run` (per Reviewer-01) — Workers bundle OK