### PR TITLE
chore(deps): bump postcss, @cloudflare/workers-types (2026-07-20)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "5.20260718.1",
+        "@cloudflare/workers-types": "5.20260719.1",
         "@happy-dom/global-registrator": "^20.11.0",
         "@playwright/test": "^1.61.1",
         "@tailwindcss/postcss": "^4.3.3",
@@ -87,7 +87,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260714.1", "", { "os": "win32", "cpu": "x64" }, "sha512-cGqnU3Hg2YZS/k3SAqrMp1DjpdsyFde72tWltdl6ZT9+SFz/Zrk/8gyTU1TcxC4YApXeNVH5TyU5cOGPgUJ0pg=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260718.1", "", {}, "sha512-PSeVPF0ZPsqv7snSwiywQX/c4jNDSXClOvFwxWoVysoltQEr6oPnOh7oRh1GoAUnVxkzzrqXbsPRTxzb3LIbag=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260719.1", "", {}, "sha512-DcGasbfUuczQilc80vhL2MPPdWcaxWkx0hN5IW9UdNDBdrRvWcal3akSJ6Ccm7e8+/OGeR+8tYrqkykA3YGSZw=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
         "lucide-react": "1.25.0",
         "marked": "18.0.6",
         "nanoid": "^6.0.0",
-        "postcss": "^8.5.19",
+        "postcss": "^8.5.20",
         "radix-ui": "^1.6.2",
         "react": "19.2.7",
         "react-dom": "19.2.7",
@@ -52,7 +52,7 @@
   "overrides": {
     "brace-expansion": "^5.0.6",
     "esbuild": "^0.28.1",
-    "postcss": "^8.5.19",
+    "postcss": "^8.5.20",
     "undici": "^7.28.0",
     "ws": "^8.20.1",
   },
@@ -799,7 +799,7 @@
 
     "playwright-core": ["playwright-core@1.61.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg=="],
 
-    "postcss": ["postcss@8.5.19", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ=="],
+    "postcss": ["postcss@8.5.20", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
@@ -971,7 +971,7 @@
 
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
-    "postcss/nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
+    "postcss/nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
 
     "pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "5.20260718.1",
+    "@cloudflare/workers-types": "5.20260719.1",
     "@happy-dom/global-registrator": "^20.11.0",
     "@playwright/test": "^1.61.1",
     "@tailwindcss/postcss": "^4.3.3",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lucide-react": "1.25.0",
     "marked": "18.0.6",
     "nanoid": "^6.0.0",
-    "postcss": "^8.5.19",
+    "postcss": "^8.5.20",
     "radix-ui": "^1.6.2",
     "react": "19.2.7",
     "react-dom": "19.2.7",
@@ -66,7 +66,7 @@
     "wrangler": "4.112.0"
   },
   "overrides": {
-    "postcss": "^8.5.19",
+    "postcss": "^8.5.20",
     "brace-expansion": "^5.0.6",
     "ws": "^8.20.1",
     "esbuild": "^0.28.1",


### PR DESCRIPTION
## Summary

Two atomic dep bumps, reviewed and approved by Reviewer-01 on STU-2038.

- `postcss` 8.5.19 → 8.5.20 (kept `overrides.postcss` in sync). Closes #246
- `@cloudflare/workers-types` 5.20260718.1 → 5.20260719.1. Closes #245

Not included:

- **#247 `radix-ui` 1.6.2 → 1.6.3** — held open. Upstream 1.6.3 shipped a d.ts packaging change (`_mergeNamespaces` frozen object) that erases namespace member types; consumers lose `React.ComponentProps<typeof SelectPrimitive.Root>` payload types and typecheck breaks with 13× `TS7006`. Reproduction + evidence in https://github.com/nocoo/dove/issues/247#issuecomment-5018130331.
- **#202 `typescript` 6.0.3 → 7.0.2** — held open. `typescript-eslint@latest` (8.64.0) and `@canary` (8.64.1-alpha.11) still declare `"typescript": ">=4.8.4 <6.1.0"`; STU-1729's blocker remains.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — 0 warnings
- [x] `bun run test` — 442/442
- [x] `bun run build` — ok
- [x] `bun run gate:deps` — osv clean
- [x] `bun run gate:secrets` — gitleaks clean
- [ ] `bun run test:e2e:api` — skipped locally (agent workspace lacks `.env.test`); expected to run in CI
