### PR TITLE
chore(deps): bump hono 4.12.32→4.12.34, undici override 7.28.0→7.29.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "entities": "^8.0.0",
-        "hono": "^4.12.32",
+        "hono": "^4.12.34",
         "jose": "^6.2.5",
         "lucide-react": "1.28.0",
         "marked": "18.0.7",
@@ -58,7 +58,7 @@
     "esbuild": "^0.28.1",
     "postcss": "^8.5.25",
     "sharp": "^0.35.0",
-    "undici": "^7.28.0",
+    "undici": "^7.29.0",
     "ws": "^8.20.1",
   },
   "packages": {
@@ -650,7 +650,7 @@
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
-    "hono": ["hono@4.12.32", "", {}, "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg=="],
+    "hono": ["hono@4.13.0", "", {}, "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ=="],
 
     "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
 
@@ -804,7 +804,7 @@
 
     "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
-    "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
+    "undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
 
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
 		"entities": "^8.0.0",
-		"hono": "^4.12.32",
+		"hono": "^4.12.34",
 		"jose": "^6.2.5",
 		"lucide-react": "1.28.0",
 		"marked": "18.0.7",
@@ -80,7 +80,7 @@
 		"brace-expansion": "^5.0.6",
 		"ws": "^8.20.1",
 		"esbuild": "^0.28.1",
-		"undici": "^7.28.0",
+		"undici": "^7.29.0",
 		"sharp": "^0.35.0"
 	}
 }


### PR DESCRIPTION
Security remediation to clear `gate:deps` failures blocking the pre-push hook for parent issue STU-2316.

## Changes

- `hono` `^4.12.32` → `^4.12.34` — resolves GHSA-8j4g-w8fx-2239 (CVSS 5.3)
- `overrides.undici` `^7.28.0` → `^7.29.0` — resolves 5 undici advisories:
  - GHSA-4cwx-7wf7-3272 (CVSS 7.4, High)
  - GHSA-8xcm-r25x-g524 (CVSS 4.8)
  - GHSA-jr45-8vmc-qm54 (CVSS 5.9)
  - GHSA-m8rv-5g2x-5cg5 (CVSS 4.2)
  - GHSA-v3r7-h72x-cjcm (CVSS 4.8)

Resolved versions after `bun install`: `hono@4.13.0` (satisfies `^4.12.34`), `undici@7.29.0`.
`bun.lock` written via official registry — no mirror URLs.

## Verification

- `bun run gate:deps` — passed (previously failed with 6 advisories)
- `bun run gate:security` — passed (osv + gitleaks)
- `bun run typecheck` — 0 errors
- `bun run lint` — 0 warnings
- `bun run test:coverage` — 442 tests / 36 files green; 99.89 / 96.73 / 100 / 99.89
- `bun run build` — ok
- `bun run test:e2e:api` (L2) — 74 pass / 0 fail

Closes STU-2493. Unblocks STU-2316.