### PR TITLE
STU-2842: bump lucide-react to 1.29.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "entities": "^8.0.0",
         "hono": "4.13.0",
         "jose": "^6.2.7",
-        "lucide-react": "1.28.0",
+        "lucide-react": "1.29.0",
         "marked": "18.0.9",
         "nanoid": "6.0.1",
         "postcss": "^8.5.25",
@@ -700,7 +700,7 @@
 
     "lint-staged": ["lint-staged@17.3.0", "", { "dependencies": { "picomatch": "^4.0.5", "string-argv": "^0.3.2", "tinyexec": "^1.2.4" }, "optionalDependencies": { "yaml": "^2.9.0" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-woZS3vNe3UKqBaLPvbLOtKRY4tLANpWQhom12MGWqC8Mh1lCOO+WgSwmX2amjJAqTY9BkXYW87fCUH5H9Ph6xw=="],
 
-    "lucide-react": ["lucide-react@1.28.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-fARAFJULsGuDDydjp6+6blekG/sBIM29TerzLjc9bQUKAcEfrSc4ZQKb25KRz4OMKd87cZTb5dgq0w/T6KufVg=="],
+    "lucide-react": ["lucide-react@1.29.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Xs9QFG5+9sNX04MdKVT4++umA+hJ2qsJVlRlRWHQ7qZobXgMiNHSpZ5eZm8JUoGCdNyoEdXoEwa8HVr0DNjOQg=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"entities": "^8.0.0",
 		"hono": "4.13.0",
 		"jose": "^6.2.7",
-		"lucide-react": "1.28.0",
+		"lucide-react": "1.29.0",
 		"marked": "18.0.9",
 		"nanoid": "6.0.1",
 		"postcss": "^8.5.25",


### PR DESCRIPTION
## Summary

- bump `lucide-react` from `1.28.0` to `1.29.0`
- refresh the Bun lockfile entry and integrity hash

## Validation

- `bun install --frozen-lockfile`
- `bun run build`
- `bun run typecheck`
- `bun run lint`
- `bun run test:coverage` (442 tests)
- `bun run test:e2e:api` (74 tests)
- `bun run test:e2e:bdd` (19 tests)
- `bun run gate:security`
- route coverage 35/35; page coverage 12/12

Closes STU-2842
Closes #312
