### PR TITLE
STU-2841: bump postcss to 8.5.26

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
         "lucide-react": "1.28.0",
         "marked": "18.0.9",
         "nanoid": "6.0.1",
-        "postcss": "^8.5.25",
+        "postcss": "8.5.26",
         "radix-ui": "^1.6.7",
         "react": "19.2.8",
         "react-dom": "19.2.8",
@@ -56,7 +56,7 @@
   "overrides": {
     "brace-expansion": "^5.0.6",
     "esbuild": "^0.28.1",
-    "postcss": "^8.5.25",
+    "postcss": "^8.5.26",
     "sharp": "^0.35.0",
     "undici": "^7.29.0",
     "ws": "^8.20.1",
@@ -730,7 +730,7 @@
 
     "playwright-core": ["playwright-core@1.62.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw=="],
 
-    "postcss": ["postcss@8.5.25", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw=="],
+    "postcss": ["postcss@8.5.26", "", { "dependencies": { "nanoid": "^3.3.17", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ=="],
 
     "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 
@@ -876,7 +876,7 @@
 
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
-    "postcss/nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
+    "postcss/nanoid": ["nanoid@3.3.17", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g=="],
 
     "pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 		"lucide-react": "1.28.0",
 		"marked": "18.0.9",
 		"nanoid": "6.0.1",
-		"postcss": "^8.5.25",
+		"postcss": "8.5.26",
 		"radix-ui": "^1.6.7",
 		"react": "19.2.8",
 		"react-dom": "19.2.8",
@@ -76,7 +76,7 @@
 		"wrangler": "4.119.0"
 	},
 	"overrides": {
-		"postcss": "^8.5.25",
+		"postcss": "^8.5.26",
 		"brace-expansion": "^5.0.6",
 		"ws": "^8.20.1",
 		"esbuild": "^0.28.1",


### PR DESCRIPTION
## Summary

- bump `postcss` from 8.5.25 to 8.5.26
- keep the package override and Bun lockfile resolution aligned
- update the transitive `nanoid` resolution to 3.3.17

## Verification

- `bun run build`
- `bun run lint`
- `bun run typecheck`
- `bun run gate:security`
- `bun run test:coverage` — 442 passed
- `bun run test:e2e:api` — 74 passed
- `bun run test:e2e:bdd` — 19 passed
- `bun install --frozen-lockfile` (independently verified by Reviewer-01)

Closes STU-2841
Closes #313
