### PR TITLE
STU-2929: bump hono to 4.13.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "entities": "^8.0.0",
-        "hono": "4.13.0",
+        "hono": "4.13.1",
         "jose": "^6.2.7",
         "lucide-react": "1.29.0",
         "marked": "18.0.9",
@@ -650,7 +650,7 @@
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
-    "hono": ["hono@4.13.0", "", {}, "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ=="],
+    "hono": ["hono@4.13.1", "", {}, "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw=="],
 
     "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
 		"entities": "^8.0.0",
-		"hono": "4.13.0",
+		"hono": "4.13.1",
 		"jose": "^6.2.7",
 		"lucide-react": "1.29.0",
 		"marked": "18.0.9",


### PR DESCRIPTION
## Summary

- bump `hono` from 4.13.0 to 4.13.1
- update the Bun lockfile integrity entry

## Verification

- `bun install --frozen-lockfile`
- `bun run typecheck`
- `bun run lint`
- `bun run test` (442 tests)
- `bun run test:e2e:api` (74 tests)
- `bun run build`
- `bun run gate:deps`

Closes #321
Closes STU-2929
