### PR TITLE
STU-2928: bump lucide-react to 1.30.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "entities": "^8.0.0",
         "hono": "4.13.1",
         "jose": "^6.2.7",
-        "lucide-react": "1.29.0",
+        "lucide-react": "1.30.0",
         "marked": "18.0.9",
         "nanoid": "6.0.1",
         "postcss": "8.5.26",
@@ -700,7 +700,7 @@
 
     "lint-staged": ["lint-staged@17.3.0", "", { "dependencies": { "picomatch": "^4.0.5", "string-argv": "^0.3.2", "tinyexec": "^1.2.4" }, "optionalDependencies": { "yaml": "^2.9.0" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-woZS3vNe3UKqBaLPvbLOtKRY4tLANpWQhom12MGWqC8Mh1lCOO+WgSwmX2amjJAqTY9BkXYW87fCUH5H9Ph6xw=="],
 
-    "lucide-react": ["lucide-react@1.29.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Xs9QFG5+9sNX04MdKVT4++umA+hJ2qsJVlRlRWHQ7qZobXgMiNHSpZ5eZm8JUoGCdNyoEdXoEwa8HVr0DNjOQg=="],
+    "lucide-react": ["lucide-react@1.30.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-tUIr2jXLbWpCkdtH8XP7P7YppM9ueWgTky99lpWDY6z5REs6B+O6ZQ3U5tHkUUY59ANyOv/PBcs8E4Fe3KO3eA=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"entities": "^8.0.0",
 		"hono": "4.13.1",
 		"jose": "^6.2.7",
-		"lucide-react": "1.29.0",
+		"lucide-react": "1.30.0",
 		"marked": "18.0.9",
 		"nanoid": "6.0.1",
 		"postcss": "8.5.26",


### PR DESCRIPTION
## Summary

- bump `lucide-react` from `1.29.0` to `1.30.0`
- refresh the Bun lockfile entry and integrity hash
- preserve React 19 peer compatibility with no unrelated dependency drift

## Validation

- `bun install --frozen-lockfile`
- `bun run lint`
- `bun run typecheck`
- `bun run test` (36 files, 442 tests)
- `bun run build`
- `bun run gate:deps`
- pre-push API E2E (74 tests)

Closes STU-2928
Closes #322
