### PR TITLE
STU-3121: bump @cloudflare/workers-types to 5.20260810.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.5.7",
-        "@cloudflare/workers-types": "5.20260809.1",
+        "@cloudflare/workers-types": "5.20260810.1",
         "@happy-dom/global-registrator": "^20.11.2",
         "@playwright/test": "^1.62.0",
         "@tailwindcss/postcss": "^4.3.3",
@@ -110,7 +110,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260801.1", "", { "os": "win32", "cpu": "x64" }, "sha512-2oQz+Ksu4ji6e/+ZoYX+tWQEcxAii2p7l+iR8kx48W1llMalaufAsmVxTlk+3/vrM7D3/2c0iK448e0UQTcIMg=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260809.1", "", {}, "sha512-sBM+0I5lCY9LgTnorn/N2UyrA6KVbUzj9tncxwH8v6sH8tVeAyJj+i0z3xXWY4l4fd1oDcwt8CGf50vGwVISYQ=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260810.1", "", {}, "sha512-aD0hEU6HaiG4wy4hDoPoLXMH963nHD4MsIY566pGkWO2dL/yeYEiMN7SeJ24t+wBmLDnh16yQ7IPos5opGkIoA=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.5.7",
-		"@cloudflare/workers-types": "5.20260809.1",
+		"@cloudflare/workers-types": "5.20260810.1",
 		"@happy-dom/global-registrator": "^20.11.2",
 		"@playwright/test": "^1.62.0",
 		"@tailwindcss/postcss": "^4.3.3",


### PR DESCRIPTION
## Summary

- bump `@cloudflare/workers-types` from `5.20260809.1` to `5.20260810.1`
- refresh the Bun lockfile entry and integrity hash

## Verification

- `bun run lint`
- `bun run typecheck`
- `bun run test` (442/442)
- `bun run build`
- pre-commit gates: typecheck, lint-staged, secrets, routes, pages, coverage
- pre-push: `test:e2e:api` (74/74), `gate:deps`
- Reviewer-01 independent re-run: frozen install, lint, typecheck, 442 tests — approved

Closes STU-3121
Closes #333