### PR TITLE
STU-3123: chore(deps): bump sonner to 2.0.8

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
         "react-dom": "19.2.8",
         "react-router": "^8.3.0",
         "recharts": "^3.10.1",
-        "sonner": "^2.0.7",
+        "sonner": "2.0.8",
         "tailwind-merge": "^3.6.0",
         "zod": "^4.4.3",
       },
@@ -770,7 +770,7 @@
 
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
 
-    "sonner": ["sonner@2.0.7", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w=="],
+    "sonner": ["sonner@2.0.8", "", { "peerDependencies": { "@types/react": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-UM/ByIoFra8yzV75n1o0Puu0bw5U/9UNnDacrJNspekBewIfsQ3D6ez1nvlWpt7aTsO6rujQtifBpycwIivqlg=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		"react-dom": "19.2.8",
 		"react-router": "^8.3.0",
 		"recharts": "^3.10.1",
-		"sonner": "^2.0.7",
+		"sonner": "2.0.8",
 		"tailwind-merge": "^3.6.0",
 		"zod": "^4.4.3"
 	},


### PR DESCRIPTION
## Summary
- Bump `sonner` from `2.0.7` to `2.0.8`
- Lockfile-only change (`package.json` + `bun.lock`)

Closes #335
Closes STU-3123

## Test plan
- [x] `tsc --noEmit`
- [x] biome lint
- [x] vitest coverage (442 tests)
- [x] pre-commit gates (secrets/routes/pages)
- [x] L2 e2e (pre-push, 74 pass)