### PR TITLE
STU-3544: chore(deps): bump hono to 4.13.2

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "entities": "^8.0.0",
-        "hono": "4.13.1",
+        "hono": "4.13.2",
         "jose": "^6.2.7",
         "lucide-react": "1.31.0",
         "marked": "18.0.9",
@@ -650,7 +650,7 @@
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
-    "hono": ["hono@4.13.1", "", {}, "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw=="],
+    "hono": ["hono@4.13.2", "", {}, "sha512-JydRilDRkYBQMt9qR9U92mXxmbGqsqSn/IKOrh4e7/gEbn+0zSr8igTu0obwJoNGN4sez28DIql7FBHWydoJpA=="],
 
     "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
 		"entities": "^8.0.0",
-		"hono": "4.13.1",
+		"hono": "4.13.2",
 		"jose": "^6.2.7",
 		"lucide-react": "1.31.0",
 		"marked": "18.0.9",


### PR DESCRIPTION
## Summary
- Bump `hono` from `4.13.1` to `4.13.2` (patch)
- No business code changes; project only uses `hono` core and `hono/factory`

Closes STU-3544
Closes #354

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test` (442 tests)
- [x] `bun run test:webhook` (56 tests)
- [x] Reviewer-01 approved locally