### PR TITLE
STU-3545: chore(deps): bump transitive nanoid 3.3.17 → 3.3.18

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -872,7 +872,7 @@
 
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
-    "postcss/nanoid": ["nanoid@3.3.17", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g=="],
+    "postcss/nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
     "pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 


### PR DESCRIPTION
## Summary
- Security bump of transitive `postcss → nanoid` from `3.3.17` to `3.3.18` (GHSA-2v37-7h3g-55p8)
- Direct dependency `nanoid@6.0.1` unchanged
- Lockfile-only change

Closes STU-3545
Closes #355

## Test plan
- [x] `bun run typecheck` / lint-staged / secrets / routes / pages gates
- [x] `vitest run --coverage` (442 tests)
- [x] `bun run gate:deps` (osv-scanner)
- [x] Reviewer-01 approved locally