### PR TITLE
STU-3676: chore(deps) bump @cloudflare/workers-types to 5.20260817.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.5.8",
-        "@cloudflare/workers-types": "5.20260814.1",
+        "@cloudflare/workers-types": "5.20260817.1",
         "@happy-dom/global-registrator": "^20.11.2",
         "@playwright/test": "^1.62.0",
         "@tailwindcss/postcss": "^4.3.3",
@@ -110,7 +110,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260811.1", "", { "os": "win32", "cpu": "x64" }, "sha512-g6VquwjASlYAibcNW/0E6Zszht4qLkmnXOGwIjjRHl2A0Qz48kVeMcGvyH6eA0G9U3OzZojjYFpP+YeyQmmdjw=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260814.1", "", {}, "sha512-bF5RT5bmxEaHJR2PRrAmcdf09EPxpRXXzPHcOtjX//r84jZNpwslNwx291ofNdBVuqGV129CBJzxiMYsB37DHw=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260817.1", "", {}, "sha512-5Dv+cyjusBTPLMRedUCiLJu3zqeeupgyn1QcHmpHJV9k/TjQAxx79AO8RVtpjVaO2CB+Oh3ywAp1UuNpbyDjGQ=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.5.8",
-		"@cloudflare/workers-types": "5.20260814.1",
+		"@cloudflare/workers-types": "5.20260817.1",
 		"@happy-dom/global-registrator": "^20.11.2",
 		"@playwright/test": "^1.62.0",
 		"@tailwindcss/postcss": "^4.3.3",


### PR DESCRIPTION
## Summary

- Bump `@cloudflare/workers-types` from `5.20260814.1` → `5.20260817.1`
- Lockfile updated via official registry (no mirror pollution)

Closes #364
Closes STU-3676

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test` (458 passed)
- [x] Pre-commit gates (typecheck, lint-staged, secrets, routes, pages, coverage)
- [x] Pre-push L2 E2E (75 passed) + G2 deps scan