### PR TITLE
chore(deps): bump @cloudflare/workers-types to 5.20260818.1 (GH #366)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.5.8",
-        "@cloudflare/workers-types": "5.20260817.1",
+        "@cloudflare/workers-types": "5.20260818.1",
         "@happy-dom/global-registrator": "^20.11.2",
         "@playwright/test": "^1.62.0",
         "@tailwindcss/postcss": "^4.3.3",
@@ -110,7 +110,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260811.1", "", { "os": "win32", "cpu": "x64" }, "sha512-g6VquwjASlYAibcNW/0E6Zszht4qLkmnXOGwIjjRHl2A0Qz48kVeMcGvyH6eA0G9U3OzZojjYFpP+YeyQmmdjw=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260817.1", "", {}, "sha512-5Dv+cyjusBTPLMRedUCiLJu3zqeeupgyn1QcHmpHJV9k/TjQAxx79AO8RVtpjVaO2CB+Oh3ywAp1UuNpbyDjGQ=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260818.1", "", {}, "sha512-a89taQDbqb7Ni+xAVSsiOSd5wQPcbBJBnZgIG3EujVdDcdQkGVwab3xa2e9z29uqtMQb/P2gYDeDcNXcBRSWQQ=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.5.8",
-		"@cloudflare/workers-types": "5.20260817.1",
+		"@cloudflare/workers-types": "5.20260818.1",
 		"@happy-dom/global-registrator": "^20.11.2",
 		"@playwright/test": "^1.62.0",
 		"@tailwindcss/postcss": "^4.3.3",


### PR DESCRIPTION
Closes STU-3686
Fixes #366

## Summary
- Bump `@cloudflare/workers-types` from `5.20260817.1` to `5.20260818.1`
- Lockfile integrity hash updated accordingly

## Test plan
- [x] `bun install --frozen-lockfile`
- [x] `typecheck` / `lint` / `build`
- [x] `gate:deps`
- [x] `test:coverage` (458/458)
- [x] `test:e2e:api` (75/75)
- [x] Reviewer-01 approved (local review before push)