### PR TITLE
STU-4045: chore(deps): bump @cloudflare/workers-types to 5.20260821.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.5.9",
-        "@cloudflare/workers-types": "5.20260820.1",
+        "@cloudflare/workers-types": "5.20260821.1",
         "@happy-dom/global-registrator": "^20.11.6",
         "@playwright/test": "^1.62.0",
         "@tailwindcss/postcss": "^4.3.3",
@@ -110,7 +110,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260815.1", "", { "os": "win32", "cpu": "x64" }, "sha512-PiIUWrhbMg3quolwjgMvPOd75vKESjT4aDm7nL6mSjL5IOgmpO/zKstXnYfnEH3pq7sC0UCvKlF8ZPcfsh8NMw=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260820.1", "", {}, "sha512-KFRmtV4toMf1LL2yXylFTIs7YAS1IYo6jrJCneBG8I1VXHcKCIdqPROH6lGum+gZ+ZgdcNZqxDgjM1yEMgma2w=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260821.1", "", {}, "sha512-jZiTISghTPeytJ7eDt5K1AV7df998xGECMgT8oy838VfFLJLROvdLzDaJb0/Jv4WfxO00keNoWt1d6olL7URRg=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.5.9",
-		"@cloudflare/workers-types": "5.20260820.1",
+		"@cloudflare/workers-types": "5.20260821.1",
 		"@happy-dom/global-registrator": "^20.11.6",
 		"@playwright/test": "^1.62.0",
 		"@tailwindcss/postcss": "^4.3.3",


### PR DESCRIPTION
## Summary
- Bump `@cloudflare/workers-types` from `5.20260820.1` to `5.20260821.1`
- Isolated single-package bump (no other dependency drift)

Closes STU-4045
Closes #387

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test` (38 files / 458 tests)
- [x] `bun run test:coverage` (Statements 99.9% / Lines 99.89%)
- [x] pre-commit gates (secrets / routes / pages / coverage)
- [x] pre-push L2 API E2E (75 pass) + `gate:deps`
- [x] Reviewer-01 approved on branch `agent/sde-01/d0dcedd4` (`8bdd171`)