### PR TITLE
STU-4232: chore(deps) bump workers-types and user-event

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -30,7 +30,7 @@
         "@playwright/test": "^1.62.0",
         "@tailwindcss/postcss": "^4.3.3",
         "@testing-library/react": "^16.3.2",
-        "@testing-library/user-event": "14.6.5",
+        "@testing-library/user-event": "14.6.6",
         "@types/bun": "1.4.0",
         "@types/node": "26.2.0",
         "@types/react": "^19.2.18",
@@ -449,7 +449,7 @@
 
     "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
 
-    "@testing-library/user-event": ["@testing-library/user-event@14.6.5", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-FhqjldLTpteueBaKflhNFlMT3+PM0O5fiBUivht6b9CZ1eesJyy7+g3Jr7XwJzt/Hip3ZG5hWwK1MX1FuDiE4w=="],
+    "@testing-library/user-event": ["@testing-library/user-event@14.6.6", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-Jbs9FpkkIDw8FgSc6kOVsOv8JuuqGAL7J4X1oot77JxAoDlkNn2GRkd0aYRVuQ+pVQAiHWVkE4rX/dkF5fBiCw=="],
 
     "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.5.10",
-        "@cloudflare/workers-types": "5.20260822.1",
+        "@cloudflare/workers-types": "5.20260823.1",
         "@happy-dom/global-registrator": "^20.11.6",
         "@playwright/test": "^1.62.0",
         "@tailwindcss/postcss": "^4.3.3",
@@ -111,7 +111,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260820.1", "", { "os": "win32", "cpu": "x64" }, "sha512-BPvCuMxIQfA47wtYsGbBG6Bcar57Qs7yHqU2jWkT1+sRnL/741/ZbQGP9kVRMQ5fwBMuqNFmQRzAu8gSm7ri/w=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260822.1", "", {}, "sha512-z922wN0pEWwYaAcYdncSf11fTPfj2j1Q2n2LCLbtBBhpkIu/aC8fotol5q4ek4isWgTKfWzUx389Dsa+lhF6yw=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260823.1", "", {}, "sha512-HdBVDR/gecQ5QwB+DZ9kB5yjNZLS85fe8bMB2K/k0xmCvaoMlAFrQQGLaCBYR00j+i9aTkQzwfrPInVZwlMPwQ=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
 		"@playwright/test": "^1.62.0",
 		"@tailwindcss/postcss": "^4.3.3",
 		"@testing-library/react": "^16.3.2",
-		"@testing-library/user-event": "14.6.5",
+		"@testing-library/user-event": "14.6.6",
 		"@types/bun": "1.4.0",
 		"@types/node": "26.2.0",
 		"@types/react": "^19.2.18",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.5.10",
-		"@cloudflare/workers-types": "5.20260822.1",
+		"@cloudflare/workers-types": "5.20260823.1",
 		"@happy-dom/global-registrator": "^20.11.6",
 		"@playwright/test": "^1.62.0",
 		"@tailwindcss/postcss": "^4.3.3",


### PR DESCRIPTION
## Summary

Dependency bump batch for [STU-4232](https://stu.nocoo.dev) / Multica issue.

- `@cloudflare/workers-types` 5.20260822.1 → 5.20260823.1 (closes nocoo/dove#399)
- `@testing-library/user-event` 14.6.5 → 14.6.6 (closes nocoo/dove#400)

Atomic commits only touch `package.json` + `bun.lock`. No application code changes.

## Test plan

- [x] pre-commit: typecheck, lint-staged, gitleaks, routes/pages gates, unit+coverage (38 files / 458 tests)
- [x] pre-push: L2 API E2E (75 pass / 0 fail), osv-scanner deps gate
- [x] Reviewer-01 independent re-verification (typecheck, lint, build, security, coverage)

Closes STU-4232