### PR TITLE
[STU-4279] deps: @types/react-dom 19.2.4 → 19.2.5

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
         "@types/bun": "1.4.0",
         "@types/node": "26.2.0",
         "@types/react": "^19.2.18",
-        "@types/react-dom": "^19.2.4",
+        "@types/react-dom": "^19.2.5",
         "@vitejs/plugin-react": "6.1.0",
         "@vitest/coverage-v8": "4.1.11",
         "husky": "^9.1.7",
@@ -483,7 +483,7 @@
 
     "@types/react": ["@types/react@19.2.18", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w=="],
 
-    "@types/react-dom": ["@types/react-dom@19.2.4", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw=="],
+    "@types/react-dom": ["@types/react-dom@19.2.5", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-fMPwH9v7r/pp43yUd2/Mbiex5KouJwwR3dzHkhLREUC6764VyDsqxhAxv6OFEYR1RhjOyD1naqba8ECDBe7ZQg=="],
 
     "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
 

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
 		"@types/bun": "1.4.0",
 		"@types/node": "26.2.0",
 		"@types/react": "^19.2.18",
-		"@types/react-dom": "^19.2.4",
+		"@types/react-dom": "^19.2.5",
 		"@vitejs/plugin-react": "6.1.0",
 		"@vitest/coverage-v8": "4.1.11",
 		"husky": "^9.1.7",


### PR DESCRIPTION
[STU-4279] Deps upgrade: @types/react-dom 19.2.4 → 19.2.5

## Summary

Upgrade `@types/react-dom` from `^19.2.4` to `^19.2.5`.

## Changes

- `package.json`: `@types/react-dom` version bump
- `bun.lock`: updated resolution hash

## Verification

- lint ✅
- typecheck ✅
- 458 unit tests ✅ (38 test files)
- build ✅
- coverage gate 99.9% ✅

Closes #402
