### PR TITLE
deps: upgrade @types/node 26.2.0 → 26.3.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -32,7 +32,7 @@
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "14.6.6",
         "@types/bun": "1.4.0",
-        "@types/node": "26.2.0",
+        "@types/node": "26.3.0",
         "@types/react": "^19.2.18",
         "@types/react-dom": "^19.2.5",
         "@vitejs/plugin-react": "6.1.0",
@@ -479,7 +479,7 @@
 
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
-    "@types/node": ["@types/node@26.2.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg=="],
+    "@types/node": ["@types/node@26.3.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-L3fgrnchriRC2ExBflb8j4uZZURHZfQsmQeyVzhjcHW4kkwVyo8/0h1B2MVzMTrYUJYu6G7EWs14hW/L9putqw=="],
 
     "@types/react": ["@types/react@19.2.18", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w=="],
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
 		"@testing-library/react": "^16.3.2",
 		"@testing-library/user-event": "14.6.6",
 		"@types/bun": "1.4.0",
-		"@types/node": "26.2.0",
+		"@types/node": "26.3.0",
 		"@types/react": "^19.2.18",
 		"@types/react-dom": "^19.2.5",
 		"@vitejs/plugin-react": "6.1.0",


### PR DESCRIPTION
## Summary

Upgrade `@types/node` dev dependency from `26.2.0` to `26.3.0`.

## Changes

- `package.json`: `@types/node` `26.2.0` → `26.3.0`
- `bun.lock`: updated accordingly

## Verification

- 458 tests passed
- TypeScript typecheck passed
- All gates passed: lint, secrets, routes, pages, coverage (99.9/96.8/100/99.89)

Closes #404
Closes STU-4398