### PR TITLE
STU-4395: chore(deps): bump marked to 18.0.11

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "hono": "4.13.3",
         "jose": "6.2.10",
         "lucide-react": "1.33.0",
-        "marked": "18.0.10",
+        "marked": "18.0.11",
         "nanoid": "6.0.1",
         "postcss": "8.5.26",
         "radix-ui": "^1.6.7",
@@ -703,7 +703,7 @@
 
     "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
 
-    "marked": ["marked@18.0.10", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-FJeH4bRpYoXiggcgriCGItKCSv3xkngJc4QCZ/rkQCogU3VYaLxYJoZl8Nw/b4+x7iij/pd+09mZ6A1dXzpL0A=="],
+    "marked": ["marked@18.0.11", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-HnslJfsZkRPBDJRHvVtAaWlZHEpSu7u8LgQuJCELjRKuWR+hpq4A7sLq3p8HaI9ypVoXDXxV34CsQJEe1+J5Aw=="],
 
     "miniflare": ["miniflare@5.20260820.0-alpha", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.35.2", "undici": "7.29.0", "workerd": "1.20260820.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" } }, "sha512-Bv1j2kcKKNwXLWuCx+j0xGt7z318mqQkJmEN6ellM9sCESbPBDTM9ofZMbKqx47jSnoGA3CiaUkAmzGVXUa/wQ=="],
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"hono": "4.13.3",
 		"jose": "6.2.10",
 		"lucide-react": "1.33.0",
-		"marked": "18.0.10",
+		"marked": "18.0.11",
 		"nanoid": "6.0.1",
 		"postcss": "8.5.26",
 		"radix-ui": "^1.6.7",


### PR DESCRIPTION
## Summary
- Bump `marked` from 18.0.10 to 18.0.11 (patch).
- Upstream fixes parser edge cases only; no API changes to `marked.parse` / custom `safeRenderer` usage in `src/lib/email/render.ts`.

Closes STU-4395
Fixes #407

## Test plan
- [x] `bun run test` — 38 files / 458 tests passed
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] pre-push L2 E2E — 75 pass / 0 fail
- [x] pre-push G2 deps (osv-scanner) passed