### PR TITLE
deps: upgrade lucide-react 1.33.0 → 1.34.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "entities": "^8.0.0",
         "hono": "4.13.3",
         "jose": "6.2.10",
-        "lucide-react": "1.33.0",
+        "lucide-react": "1.34.0",
         "marked": "18.0.11",
         "nanoid": "6.0.1",
         "postcss": "8.5.26",
@@ -693,7 +693,7 @@
 
     "lint-staged": ["lint-staged@17.3.0", "", { "dependencies": { "picomatch": "^4.0.5", "string-argv": "^0.3.2", "tinyexec": "^1.2.4" }, "optionalDependencies": { "yaml": "^2.9.0" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-woZS3vNe3UKqBaLPvbLOtKRY4tLANpWQhom12MGWqC8Mh1lCOO+WgSwmX2amjJAqTY9BkXYW87fCUH5H9Ph6xw=="],
 
-    "lucide-react": ["lucide-react@1.33.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-MTRwMy0ZlL8Ur/vOAiJ9XGHE+kFPC7brq6MxAm0GiGXEBj0qy0jA/pG4N675oSzciO/UCdX8T+5yUQdmDeTLxg=="],
+    "lucide-react": ["lucide-react@1.34.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-vnjGJNI7Htk5+oWW8gXGuaLgwgAb0T6/iZbBrp9JCfRFwdNWZ0YTm3eyxjOLgwN6r8iyAf3UA70zNmBRBNv7yg=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"entities": "^8.0.0",
 		"hono": "4.13.3",
 		"jose": "6.2.10",
-		"lucide-react": "1.33.0",
+		"lucide-react": "1.34.0",
 		"marked": "18.0.11",
 		"nanoid": "6.0.1",
 		"postcss": "8.5.26",


### PR DESCRIPTION
Closes STU-4396
Closes #406

## Summary

Upgrade `lucide-react` from `1.33.0` to `1.34.0` per [nocoo/dove#406](https://github.com/nocoo/dove/issues/406).

## Changes

- `package.json`: `lucide-react` pinned to `1.34.0`
- `bun.lock`: updated accordingly

## Verification

- ✅ typecheck (tsc --noEmit)
- ✅ lint (Biome 130 files)
- ✅ 38/38 test files, 458/458 tests passed
- ✅ Coverage gate: 99.9 / 96.8 / 100 / 99.89
- ✅ security / secrets / routes / pages gates