### PR TITLE
STU-4850: bump @testing-library/user-event to 14.6.7

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -30,7 +30,7 @@
         "@playwright/test": "^1.62.0",
         "@tailwindcss/postcss": "^4.3.3",
         "@testing-library/react": "^16.3.3",
-        "@testing-library/user-event": "14.6.6",
+        "@testing-library/user-event": "14.6.7",
         "@types/bun": "1.4.0",
         "@types/node": "26.4.0",
         "@types/react": "^19.2.18",
@@ -449,7 +449,7 @@
 
     "@testing-library/react": ["@testing-library/react@16.3.3", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Uo193NgQbPMz6lrrhtRQQFcMC6Re/ELLFbbuVL30WDlZxlpZf9/lMHTAVxPRLw1q1iu9OJmR1c2BLiENRstdBg=="],
 
-    "@testing-library/user-event": ["@testing-library/user-event@14.6.6", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-Jbs9FpkkIDw8FgSc6kOVsOv8JuuqGAL7J4X1oot77JxAoDlkNn2GRkd0aYRVuQ+pVQAiHWVkE4rX/dkF5fBiCw=="],
+    "@testing-library/user-event": ["@testing-library/user-event@14.6.7", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-MPCpX8bxe8zS+JmmTwLp8jd0dy1rAm60Te/SL8JrQM3qvQJcBOs1d7IefJMyZzqM3EWBrDn/LWDt1BCGu4ASfg=="],
 
     "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
 		"@playwright/test": "^1.62.0",
 		"@tailwindcss/postcss": "^4.3.3",
 		"@testing-library/react": "^16.3.3",
-		"@testing-library/user-event": "14.6.6",
+		"@testing-library/user-event": "14.6.7",
 		"@types/bun": "1.4.0",
 		"@types/node": "26.4.0",
 		"@types/react": "^19.2.18",


### PR DESCRIPTION
## Summary

- bump `@testing-library/user-event` from 14.6.6 to 14.6.7
- regenerate the matching Bun lockfile entry

## Validation

- `bun run test`
- `bun run typecheck`
- `bun run lint`
- `bun run test:e2e:api`
- `bun run gate:deps`
- `bun install --frozen-lockfile --ignore-scripts`

Closes #446
