### PR TITLE
STU-4856: upgrade lucide-react to 1.40.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "entities": "^8.0.0",
         "hono": "4.13.5",
         "jose": "6.2.10",
-        "lucide-react": "1.38.0",
+        "lucide-react": "1.40.0",
         "marked": "18.0.11",
         "nanoid": "6.0.1",
         "postcss": "8.5.26",
@@ -693,7 +693,7 @@
 
     "lint-staged": ["lint-staged@17.4.1", "", { "dependencies": { "picomatch": "^4.0.7", "string-argv": "^0.3.2", "tinyexec": "^1.3.0" }, "optionalDependencies": { "yaml": "^2.9.0" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-FmJeudcalbSfg1du+JCfvi5vS6Qt08KgbfLWiHinbef+2JJwUZwAWVoaO1AcJVUTWPfk0t30PMQNwPAeCzYQ+Q=="],
 
-    "lucide-react": ["lucide-react@1.38.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-xZCyBd/wiVUDactoCc+42TjL0aB7EBOXsuX+tjz+W/sGzw2KhHpL1NOH3FIaVUcpimvUBpIYfz34Ofj9S5JEzQ=="],
+    "lucide-react": ["lucide-react@1.40.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-MaG+8WnOXkDWz9XeElj7TnQ890tTZUB0a36i03aRRCKGWE6e7jJpmdCvtxxuxcjjdqyN6m4sL6qlHVuSUDtYgg=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"entities": "^8.0.0",
 		"hono": "4.13.5",
 		"jose": "6.2.10",
-		"lucide-react": "1.38.0",
+		"lucide-react": "1.40.0",
 		"marked": "18.0.11",
 		"nanoid": "6.0.1",
 		"postcss": "8.5.26",


### PR DESCRIPTION
## Summary

- Upgrade `lucide-react` from 1.38.0 to 1.40.0.
- Refresh the Bun lockfile with the resolved package integrity hash.

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun run test` (38 files, 458 tests)

Closes #452
Closes STU-4856
