### PR TITLE
STU-4849: chore(deps): update @types/node to 26.4.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -32,7 +32,7 @@
         "@testing-library/react": "^16.3.3",
         "@testing-library/user-event": "14.6.6",
         "@types/bun": "1.4.0",
-        "@types/node": "26.4.0",
+        "@types/node": "26.4.1",
         "@types/react": "^19.2.18",
         "@types/react-dom": "^19.2.5",
         "@vitejs/plugin-react": "6.1.1",
@@ -479,7 +479,7 @@
 
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
-    "@types/node": ["@types/node@26.4.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ=="],
+    "@types/node": ["@types/node@26.4.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA=="],
 
     "@types/react": ["@types/react@19.2.18", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w=="],
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
 		"@testing-library/react": "^16.3.3",
 		"@testing-library/user-event": "14.6.6",
 		"@types/bun": "1.4.0",
-		"@types/node": "26.4.0",
+		"@types/node": "26.4.1",
 		"@types/react": "^19.2.18",
 		"@types/react-dom": "^19.2.5",
 		"@vitejs/plugin-react": "6.1.1",


### PR DESCRIPTION
## Summary

- Update `@types/node` from 26.4.0 to 26.4.1.
- Regenerate the Bun lockfile with the matching package integrity hash.

## Validation

- `bun install --frozen-lockfile`
- `bun run typecheck`
- `bun run lint`
- `bun run gate:deps`
- `bun run test` (458 passed)
- `bun run test:e2e:api` (75 passed)

Closes #441
Closes STU-4849
