### PR TITLE
chore(deps): bump postcss to 8.5.28

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
         "lucide-react": "1.40.0",
         "marked": "18.0.11",
         "nanoid": "6.0.1",
-        "postcss": "8.5.26",
+        "postcss": "8.5.28",
         "radix-ui": "^1.6.7",
         "react": "19.2.8",
         "react-dom": "19.2.8",
@@ -56,7 +56,7 @@
   "overrides": {
     "brace-expansion": "^5.0.6",
     "esbuild": "^0.28.1",
-    "postcss": "^8.5.26",
+    "postcss": "^8.5.28",
     "sharp": "^0.35.0",
     "undici": "^7.29.0",
     "vite": "8.2.2",
@@ -703,7 +703,7 @@
 
     "playwright-core": ["playwright-core@1.62.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw=="],
 
-    "postcss": ["postcss@8.5.26", "", { "dependencies": { "nanoid": "^3.3.17", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ=="],
+    "postcss": ["postcss@8.5.28", "", { "dependencies": { "nanoid": "^3.3.18", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A=="],
 
     "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 		"lucide-react": "1.40.0",
 		"marked": "18.0.11",
 		"nanoid": "6.0.1",
-		"postcss": "8.5.26",
+		"postcss": "8.5.28",
 		"radix-ui": "^1.6.7",
 		"react": "19.2.8",
 		"react-dom": "19.2.8",
@@ -77,7 +77,7 @@
 	},
 	"overrides": {
 		"vite": "8.2.2",
-		"postcss": "^8.5.26",
+		"postcss": "^8.5.28",
 		"brace-expansion": "^5.0.6",
 		"ws": "^8.20.1",
 		"esbuild": "^0.28.1",


### PR DESCRIPTION
Closes #453

Updates the direct PostCSS dependency and its override to 8.5.28, with the Bun lockfile refreshed.

Validated: lint, typecheck, build, 458 unit tests, 75 API E2E tests, and the dependency security gate.